### PR TITLE
feat: 카드 생성 시 기본 날짜 자동 입력

### DIFF
--- a/src/app/api/businesses/[id]/progress-items/route.ts
+++ b/src/app/api/businesses/[id]/progress-items/route.ts
@@ -64,7 +64,7 @@ export async function POST(request: NextRequest, context: Params) {
       stage,
       title: trimmedTitle,
       content: trimmedContent,
-      date: date ?? "",
+      date: date || new Date().toISOString().slice(0, 10),
       sortOrder: sortOrder ?? (maxSort._max.sortOrder ?? 0) + 1,
     },
   });


### PR DESCRIPTION
## Summary
- 진행 항목(카드) 생성 시 날짜를 지정하지 않으면 오늘 날짜(YYYY-MM-DD)가 자동으로 입력되도록 변경
- 기존 `date ?? ""` (빈 문자열 허용)에서 `date || new Date().toISOString().slice(0, 10)` (falsy 값일 때 오늘 날짜)으로 수정

## Test plan
- [ ] 날짜 미입력 상태에서 카드를 생성하여 오늘 날짜가 자동 설정되는지 확인
- [ ] 날짜를 직접 입력한 경우 해당 날짜가 그대로 저장되는지 확인
- [ ] 빈 문자열("")로 날짜를 전달한 경우에도 오늘 날짜로 대체되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)