### PR TITLE
feat: 기업 DnD 순서 변경 + 좌측 컬럼 고정

### DIFF
--- a/prisma/migrations/20260319120000_add_is_pinned_to_company/migration.sql
+++ b/prisma/migrations/20260319120000_add_is_pinned_to_company/migration.sql
@@ -1,0 +1,4 @@
+-- This migration was reverted: isPinned is no longer needed.
+-- The column was added and then dropped in the same release.
+ALTER TABLE "companies" ADD COLUMN IF NOT EXISTS "is_pinned" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "companies" DROP COLUMN IF EXISTS "is_pinned";

--- a/src/app/api/companies/reorder/route.ts
+++ b/src/app/api/companies/reorder/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { createAuditLog } from "@/lib/audit";
+
+export async function PUT(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { orderedIds } = body as { orderedIds: string[] };
+
+    if (!Array.isArray(orderedIds) || orderedIds.length === 0) {
+      return NextResponse.json(
+        { error: "VALIDATION", message: "orderedIds must be a non-empty array" },
+        { status: 400 },
+      );
+    }
+
+    await prisma.$transaction(
+      orderedIds.map((id, index) =>
+        prisma.company.update({
+          where: { id },
+          data: { sortOrder: index },
+        }),
+      ),
+    );
+
+    await createAuditLog({
+      entityType: "company",
+      entityId: "batch",
+      action: "move",
+      summary: `Reordered ${orderedIds.length} companies`,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("PUT /api/companies/reorder error:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/app/business/page.tsx
+++ b/src/app/business/page.tsx
@@ -1,7 +1,24 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
-import { useCompanies } from "@/hooks/use-companies";
+import { useState, useMemo, useEffect, useRef } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragStartEvent,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useUIStore } from "@/stores/ui-store";
+import { useCompanies, useReorderCompanies } from "@/hooks/use-companies";
 import { useBusinesses } from "@/hooks/use-businesses";
 import { CompanyGroupRow } from "@/components/business-table/company-group-row";
 import { BusinessRow } from "@/components/business-table/business-row";
@@ -12,15 +29,39 @@ import { QuickActionsBar } from "@/components/ui/quick-actions";
 import { ExcelDownloadDialog } from "@/components/export/excel-download-dialog";
 import type { Company, Business } from "@/types";
 
-const STAGE_LABELS = [
-  "Inbound(초도미팅)",
-  "Funnel",
-  "Pipeline",
-  "제안",
-  "계약",
-  "구축",
-  "유지보수",
+const STAGES_CONFIG: { key: string; label: string }[] = [
+  { key: "inbound", label: "Inbound(초도미팅)" },
+  { key: "funnel", label: "Funnel" },
+  { key: "pipeline", label: "Pipeline" },
+  { key: "proposal", label: "제안" },
+  { key: "contract", label: "계약" },
+  { key: "build", label: "구축" },
+  { key: "maintenance", label: "유지보수" },
 ];
+const ALL_STAGE_KEYS = STAGES_CONFIG.map((s) => s.key);
+
+function SortableCompanyGroup({
+  companyId,
+  children,
+}: {
+  companyId: string;
+  children: (handleProps: Record<string, unknown>) => React.ReactNode;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: companyId });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      {children({ ...attributes, ...listeners })}
+    </div>
+  );
+}
 
 export default function BusinessManagementPage() {
   const [search, setSearch] = useState("");
@@ -31,6 +72,31 @@ export default function BusinessManagementPage() {
   const [showNewCompany, setShowNewCompany] = useState(false);
   const [showNewBusiness, setShowNewBusiness] = useState(false);
   const [showExcelDownload, setShowExcelDownload] = useState(false);
+  const [visibleStages, setVisibleStages] = useState<Set<string>>(
+    new Set(ALL_STAGE_KEYS),
+  );
+
+  const toggleStage = (key: string) => {
+    setVisibleStages((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        if (next.size <= 1) return prev; // 최소 1개는 유지
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  // Filter text sync to store (for MiniBlock dimming)
+  const setFilterText = useUIStore((s) => s.setSearchFilterText);
+  const setHighlightId = useUIStore((s) => s.setSearchHighlightId);
+  const filterTextRef = useRef<string | null>(null);
+
+  // Local match navigation state (NOT in zustand to avoid render loops)
+  const [matchIndex, setMatchIndex] = useState(-1);
+  const matchIdsRef = useRef<string[]>([]);
 
   // Disable body scroll so only our container scrolls (via CSS class for safety)
   useEffect(() => {
@@ -41,22 +107,75 @@ export default function BusinessManagementPage() {
   }, []);
 
   const { data: companiesData, isLoading: companiesLoading } = useCompanies({
-    search,
     isKey: showKeyOnly ? true : undefined,
   });
-  const { data: businessesData, isLoading: businessesLoading } = useBusinesses({
-    search,
-  });
+  const { data: businessesData, isLoading: businessesLoading } = useBusinesses({});
 
   const companies = companiesData?.data ?? [];
   const businesses = businessesData?.data ?? [];
 
-  // Group businesses by company, key companies first
+  // Only consider businesses belonging to visible companies
+  const visibleCompanyIds = useMemo(
+    () => new Set(companies.map((c: Company) => c.id)),
+    [companies],
+  );
+  const visibleBusinesses = useMemo(
+    () => businesses.filter((b: Business) => visibleCompanyIds.has(b.companyId)),
+    [businesses, visibleCompanyIds],
+  );
+
+  // Compute match IDs from search text (only within visible businesses)
+  const filterMatchIds = useMemo(() => {
+    if (search.length < 2) return [];
+    const lc = search.toLowerCase();
+    const ids: string[] = [];
+    for (const biz of visibleBusinesses) {
+      const items = (biz as Business & { progressItems?: { id: string; title?: string; content: string; stage: string }[] }).progressItems ?? [];
+      for (const item of items) {
+        if (!visibleStages.has(item.stage)) continue;
+        if (
+          (item.title ?? "").toLowerCase().includes(lc) ||
+          item.content.toLowerCase().includes(lc)
+        ) {
+          ids.push(item.id);
+        }
+      }
+    }
+    return ids;
+  }, [search, visibleBusinesses, visibleStages]);
+
+  // Keep ref in sync for Enter handler
+  matchIdsRef.current = filterMatchIds;
+
+  // Sync filter text to store — only when it actually changes
+  useEffect(() => {
+    const newVal = search.length >= 2 ? search : null;
+    if (filterTextRef.current !== newVal) {
+      filterTextRef.current = newVal;
+      setFilterText(newVal);
+      setMatchIndex(-1);
+    }
+  }, [search, setFilterText]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => { setFilterText(null); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const goToNextMatch = () => {
+    const ids = matchIdsRef.current;
+    if (ids.length === 0) return;
+    const next = (matchIndex + 1) % ids.length;
+    setMatchIndex(next);
+    setHighlightId(ids[next]);
+  };
+
+  // Group businesses by company, sorted by sortOrder
   const groupedData = useMemo(() => {
-    const sortedCompanies = [...companies].sort((a, b) => {
-      if (a.isKey !== b.isKey) return a.isKey ? -1 : 1;
-      return a.sortOrder - b.sortOrder;
-    });
+    const sortedCompanies = [...companies].sort(
+      (a, b) => a.sortOrder - b.sortOrder,
+    );
 
     return sortedCompanies.map((company) => ({
       company,
@@ -68,20 +187,80 @@ export default function BusinessManagementPage() {
 
   const isLoading = companiesLoading || businessesLoading;
 
+  // DnD for company reordering
+  const reorderCompanies = useReorderCompanies();
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  );
+  const [activeCompany, setActiveCompany] = useState<Company | null>(null);
+
+  const handleDragStart = (event: DragStartEvent) => {
+    const company = companies.find((c: Company) => c.id === event.active.id);
+    setActiveCompany(company ?? null);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveCompany(null);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const sortedIds = groupedData.map((g) => g.company.id);
+    const oldIndex = sortedIds.indexOf(active.id as string);
+    const newIndex = sortedIds.indexOf(over.id as string);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const reordered = [...sortedIds];
+    const [moved] = reordered.splice(oldIndex, 1);
+    reordered.splice(newIndex, 0, moved);
+
+    reorderCompanies.mutate(reordered);
+  };
+
   return (
     <div className="flex h-[calc(100vh-3.5rem)] flex-col">
       {/* Toolbar */}
       <div className="shrink-0 flex items-center gap-3 border-b border-[var(--border)] px-4 py-3">
         <h1 className="text-lg font-bold">사업관리</h1>
 
-        <input
-          type="search"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="기업 및 사업 검색..."
-          aria-label="기업 및 사업 검색"
-          className="h-8 w-64 rounded-md border border-[var(--border)] bg-[var(--muted)] px-3 text-sm outline-none focus:ring-2 focus:ring-[var(--ring)]"
-        />
+        <div className="relative flex items-center gap-2">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && filterMatchIds.length > 0) {
+                e.preventDefault();
+                goToNextMatch();
+              }
+            }}
+            placeholder="카드 필터링... (Enter로 이동)"
+            aria-label="카드 필터링"
+            className={`h-8 w-64 rounded-md border bg-[var(--muted)] px-3 pr-8 text-sm outline-none focus:ring-2 focus:ring-[var(--ring)] transition-colors ${
+              search.length >= 2
+                ? "border-[var(--primary)] bg-[var(--primary)]/5"
+                : "border-[var(--border)]"
+            }`}
+          />
+          {search && (
+            <button
+              onClick={() => setSearch("")}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+              title="필터 해제"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+
+        {search.length >= 2 && (
+          <span className="text-xs text-[var(--primary)] font-medium tabular-nums">
+            {filterMatchIds.length === 0
+              ? "결과 없음"
+              : matchIndex >= 0
+                ? `(${matchIndex + 1}/${filterMatchIds.length})`
+                : `${filterMatchIds.length}건`}
+          </span>
+        )}
 
         <label className="flex items-center gap-1.5 text-sm cursor-pointer">
           <input
@@ -119,16 +298,22 @@ export default function BusinessManagementPage() {
 
         {!isLoading && groupedData.length === 0 && (
           <div className="flex flex-col items-center justify-center p-16 text-center">
-            <p className="text-lg font-medium">등록된 기업이 없습니다</p>
-            <p className="mt-1 text-sm text-[var(--muted-foreground)]">
-              첫 번째 기업을 생성하여 시작하세요.
+            <p className="text-lg font-medium">
+              {showKeyOnly ? "중요 기업으로 등록된 기업이 없습니다" : "등록된 기업이 없습니다"}
             </p>
-            <button
-              onClick={() => setShowNewCompany(true)}
-              className="mt-4 rounded-md bg-[var(--primary)] px-4 py-2 text-sm text-[var(--primary-foreground)] hover:opacity-90"
-            >
-              + 새 기업
-            </button>
+            <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+              {showKeyOnly
+                ? "기업 목록에서 ★를 눌러 중요 기업으로 지정하세요."
+                : "첫 번째 기업을 생성하여 시작하세요."}
+            </p>
+            {!showKeyOnly && (
+              <button
+                onClick={() => setShowNewCompany(true)}
+                className="mt-4 rounded-md bg-[var(--primary)] px-4 py-2 text-sm text-[var(--primary-foreground)] hover:opacity-90"
+              >
+                + 새 기업
+              </button>
+            )}
           </div>
         )}
 
@@ -137,50 +322,95 @@ export default function BusinessManagementPage() {
           {/* Stage column headers */}
           {groupedData.length > 0 && (
             <div className="sticky top-0 z-10 flex border-b border-[var(--border)] bg-[var(--background)]">
-              <div className="w-[280px] shrink-0 border-r border-[var(--border)] px-4 py-2">
+              <div className="sticky left-0 z-20 w-[280px] shrink-0 border-r border-[var(--border)] bg-[var(--background)] px-4 py-2">
                 <span className="text-sm font-semibold text-[var(--muted-foreground)]">
                   사업 정보
                 </span>
               </div>
-              {STAGE_LABELS.map((label) => (
-                <div
-                  key={label}
-                  className="w-[300px] shrink-0 border-r border-[var(--border)] px-2 py-2"
-                >
-                  <span className="text-xs font-semibold text-[var(--muted-foreground)] uppercase">
-                    {label}
-                  </span>
-                </div>
-              ))}
+              {STAGES_CONFIG.map(({ key, label }) => {
+                const active = visibleStages.has(key);
+                return (
+                  <div
+                    key={key}
+                    onClick={() => toggleStage(key)}
+                    className={`shrink-0 border-r border-[var(--border)] cursor-pointer select-none transition-all ${
+                      active
+                        ? "w-[300px] px-2 py-2 hover:bg-[var(--muted)]"
+                        : "w-[40px] px-1 py-2 bg-[var(--muted)] opacity-40 hover:opacity-70"
+                    }`}
+                    title={active ? `${label} 숨기기` : `${label} 표시`}
+                  >
+                    <span className={`text-xs font-semibold text-[var(--muted-foreground)] uppercase ${
+                      active ? "" : "writing-mode-vertical"
+                    }`}
+                      style={active ? undefined : { writingMode: "vertical-rl", textOrientation: "mixed" }}
+                    >
+                      {label}
+                    </span>
+                  </div>
+                );
+              })}
             </div>
           )}
 
-          {groupedData.map(({ company, businesses: bizList }) => (
-            <CompanyGroupRow
-              key={company.id}
-              company={company}
-              businessCount={bizList.length}
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={groupedData.map((g) => g.company.id)}
+              strategy={verticalListSortingStrategy}
             >
-              {bizList.length === 0 && (
-                <div className="px-8 py-3 text-xs text-[var(--muted-foreground)]">
-                  등록된 사업이 없습니다.{" "}
-                  <button
-                    onClick={() => setShowNewBusiness(true)}
-                    className="text-[var(--primary)] hover:underline"
-                  >
-                    추가하기
-                  </button>
+              {groupedData.map(({ company, businesses: bizList }) => (
+                <SortableCompanyGroup key={company.id} companyId={company.id}>
+                  {(dragHandleProps) => (
+                    <CompanyGroupRow
+                      company={company}
+                      businessCount={bizList.length}
+                      dragHandleProps={dragHandleProps}
+                    >
+                      {bizList.length === 0 && (
+                        <div className="px-8 py-3 text-xs text-[var(--muted-foreground)]">
+                          등록된 사업이 없습니다.{" "}
+                          <button
+                            onClick={() => setShowNewBusiness(true)}
+                            className="text-[var(--primary)] hover:underline"
+                          >
+                            추가하기
+                          </button>
+                        </div>
+                      )}
+                      {bizList.map((biz: Business) => (
+                        <BusinessRow
+                          key={biz.id}
+                          business={{ ...biz, companyName: company.canonicalName }}
+                          onClick={() => setSelectedBusinessId(biz.id)}
+                          visibleStages={visibleStages}
+                        />
+                      ))}
+                    </CompanyGroupRow>
+                  )}
+                </SortableCompanyGroup>
+              ))}
+            </SortableContext>
+
+            <DragOverlay>
+              {activeCompany && (
+                <div className="opacity-80 rotate-1 scale-[1.02] shadow-lg rounded-md">
+                  <div className="flex items-center gap-2 bg-[var(--muted)] border border-[var(--border)] rounded-md px-4 py-2">
+                    <span className="text-lg text-yellow-500">
+                      {activeCompany.isKey ? "★" : ""}
+                    </span>
+                    <span className="font-semibold text-sm">
+                      {activeCompany.canonicalName}
+                    </span>
+                  </div>
                 </div>
               )}
-              {bizList.map((biz: Business) => (
-                <BusinessRow
-                  key={biz.id}
-                  business={{ ...biz, companyName: company.canonicalName }}
-                  onClick={() => setSelectedBusinessId(biz.id)}
-                />
-              ))}
-            </CompanyGroupRow>
-          ))}
+            </DragOverlay>
+          </DndContext>
         </div>
       </div>
 

--- a/src/components/business-table/business-row.tsx
+++ b/src/components/business-table/business-row.tsx
@@ -18,9 +18,10 @@ interface BusinessRowProps {
     progressItems?: ProgressItem[];
   };
   onClick: () => void;
+  visibleStages?: Set<string>;
 }
 
-export function BusinessRow({ business, onClick }: BusinessRowProps) {
+export function BusinessRow({ business, onClick, visibleStages }: BusinessRowProps) {
   const [selectedBlock, setSelectedBlock] = useState<ProgressItem | null>(null);
 
   return (
@@ -28,7 +29,7 @@ export function BusinessRow({ business, onClick }: BusinessRowProps) {
       <div className="flex items-stretch border-b border-[var(--border)] hover:bg-[var(--accent)]/50 transition-colors">
         {/* Fixed left column — 사업명 + 고객사명 + 공개여부 + 규모 */}
         <div
-          className="flex min-w-[280px] w-[280px] shrink-0 flex-col justify-center gap-1 border-r border-[var(--border)] px-4 py-3 cursor-pointer"
+          className="sticky left-0 z-[5] flex min-w-[280px] w-[280px] shrink-0 flex-col justify-center gap-1 border-r border-[var(--border)] bg-[var(--background)] px-4 py-3 cursor-pointer"
           onClick={onClick}
         >
           {/* 사업명 (크게) */}
@@ -65,6 +66,7 @@ export function BusinessRow({ business, onClick }: BusinessRowProps) {
           businessId={business.id}
           progressItems={(business.progressItems ?? []) as ProgressItem[]}
           onBlockClick={(item) => setSelectedBlock(item)}
+          visibleStages={visibleStages}
         />
       </div>
 

--- a/src/components/business-table/company-group-row.tsx
+++ b/src/components/business-table/company-group-row.tsx
@@ -8,20 +8,23 @@ interface CompanyGroupRowProps {
   company: Company;
   businessCount: number;
   children: React.ReactNode;
+  dragHandleProps?: Record<string, unknown>;
 }
 
 export function CompanyGroupRow({
   company,
   businessCount,
   children,
+  dragHandleProps,
 }: CompanyGroupRowProps) {
   const [expanded, setExpanded] = useState(true);
 
   return (
     <div className="border-b border-[var(--border)]">
       <div
-        className="flex cursor-pointer items-center gap-2 bg-[var(--muted)] px-4 py-2 hover:bg-[var(--accent)] transition-colors"
+        className="sticky left-0 z-[5] flex cursor-pointer items-center gap-2 bg-[var(--muted)] px-4 py-2 hover:bg-[var(--accent)] transition-colors"
         onClick={() => setExpanded(!expanded)}
+        {...dragHandleProps}
       >
         <span className="text-xs text-[var(--muted-foreground)] w-4">
           {expanded ? "▼" : "▶"}

--- a/src/hooks/use-companies.ts
+++ b/src/hooks/use-companies.ts
@@ -80,6 +80,21 @@ export function useUpdateCompany() {
   });
 }
 
+export function useReorderCompanies() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (orderedIds: string[]) =>
+      fetchJson<{ success: boolean }>("/api/companies/reorder", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orderedIds }),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["companies"] });
+    },
+  });
+}
+
 export function useArchiveCompany() {
   const qc = useQueryClient();
   return useMutation({


### PR DESCRIPTION
## Summary
- 기업 헤더 행에서 드래그앤드롭으로 기업 순서를 변경할 수 있도록 DnD 기능 추가 (`@dnd-kit/core`, `@dnd-kit/sortable`)
- 좌측 "사업 정보" 컬럼과 기업 헤더를 `sticky left-0`으로 고정하여 가로 스크롤 시에도 항상 표시
- `PUT /api/companies/reorder` 엔드포인트를 추가하여 sortOrder 일괄 업데이트 지원

## Changed files
- `src/app/business/page.tsx` — DnD context, SortableCompanyGroup, sensors, drag handlers, sticky header, stage toggle UI, card filtering
- `src/components/business-table/company-group-row.tsx` — dragHandleProps prop, sticky left-0
- `src/components/business-table/business-row.tsx` — sticky left-0 on left column, visibleStages prop
- `src/hooks/use-companies.ts` — useReorderCompanies hook
- `src/app/api/companies/reorder/route.ts` — NEW: batch sortOrder PUT endpoint
- `prisma/migrations/20260319120000_add_is_pinned_to_company/migration.sql` — reverted isPinned migration (add+drop)

## Test plan
- [ ] 기업 헤더를 드래그하여 순서 변경 후 페이지 새로고침 시 순서가 유지되는지 확인
- [ ] 가로 스크롤 시 좌측 사업 정보 컬럼과 기업 헤더가 고정되는지 확인
- [ ] DragOverlay가 드래그 중 정상적으로 표시되는지 확인
- [ ] 스테이지 컬럼 토글(숨기기/표시)이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)