### PR TITLE
feat: 검색 필터링 + 카드 하이라이트 + 스테이지 토글

### DIFF
--- a/src/app/business/page.tsx
+++ b/src/app/business/page.tsx
@@ -1,7 +1,24 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
-import { useCompanies } from "@/hooks/use-companies";
+import { useState, useMemo, useEffect, useRef } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragStartEvent,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useUIStore } from "@/stores/ui-store";
+import { useCompanies, useReorderCompanies } from "@/hooks/use-companies";
 import { useBusinesses } from "@/hooks/use-businesses";
 import { CompanyGroupRow } from "@/components/business-table/company-group-row";
 import { BusinessRow } from "@/components/business-table/business-row";
@@ -12,15 +29,39 @@ import { QuickActionsBar } from "@/components/ui/quick-actions";
 import { ExcelDownloadDialog } from "@/components/export/excel-download-dialog";
 import type { Company, Business } from "@/types";
 
-const STAGE_LABELS = [
-  "Inbound(초도미팅)",
-  "Funnel",
-  "Pipeline",
-  "제안",
-  "계약",
-  "구축",
-  "유지보수",
+const STAGES_CONFIG: { key: string; label: string }[] = [
+  { key: "inbound", label: "Inbound(초도미팅)" },
+  { key: "funnel", label: "Funnel" },
+  { key: "pipeline", label: "Pipeline" },
+  { key: "proposal", label: "제안" },
+  { key: "contract", label: "계약" },
+  { key: "build", label: "구축" },
+  { key: "maintenance", label: "유지보수" },
 ];
+const ALL_STAGE_KEYS = STAGES_CONFIG.map((s) => s.key);
+
+function SortableCompanyGroup({
+  companyId,
+  children,
+}: {
+  companyId: string;
+  children: (handleProps: Record<string, unknown>) => React.ReactNode;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: companyId });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      {children({ ...attributes, ...listeners })}
+    </div>
+  );
+}
 
 export default function BusinessManagementPage() {
   const [search, setSearch] = useState("");
@@ -31,6 +72,31 @@ export default function BusinessManagementPage() {
   const [showNewCompany, setShowNewCompany] = useState(false);
   const [showNewBusiness, setShowNewBusiness] = useState(false);
   const [showExcelDownload, setShowExcelDownload] = useState(false);
+  const [visibleStages, setVisibleStages] = useState<Set<string>>(
+    new Set(ALL_STAGE_KEYS),
+  );
+
+  const toggleStage = (key: string) => {
+    setVisibleStages((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        if (next.size <= 1) return prev; // 최소 1개는 유지
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  // Filter text sync to store (for MiniBlock dimming)
+  const setFilterText = useUIStore((s) => s.setSearchFilterText);
+  const setHighlightId = useUIStore((s) => s.setSearchHighlightId);
+  const filterTextRef = useRef<string | null>(null);
+
+  // Local match navigation state (NOT in zustand to avoid render loops)
+  const [matchIndex, setMatchIndex] = useState(-1);
+  const matchIdsRef = useRef<string[]>([]);
 
   // Disable body scroll so only our container scrolls (via CSS class for safety)
   useEffect(() => {
@@ -41,22 +107,75 @@ export default function BusinessManagementPage() {
   }, []);
 
   const { data: companiesData, isLoading: companiesLoading } = useCompanies({
-    search,
     isKey: showKeyOnly ? true : undefined,
   });
-  const { data: businessesData, isLoading: businessesLoading } = useBusinesses({
-    search,
-  });
+  const { data: businessesData, isLoading: businessesLoading } = useBusinesses({});
 
   const companies = companiesData?.data ?? [];
   const businesses = businessesData?.data ?? [];
 
-  // Group businesses by company, key companies first
+  // Only consider businesses belonging to visible companies
+  const visibleCompanyIds = useMemo(
+    () => new Set(companies.map((c: Company) => c.id)),
+    [companies],
+  );
+  const visibleBusinesses = useMemo(
+    () => businesses.filter((b: Business) => visibleCompanyIds.has(b.companyId)),
+    [businesses, visibleCompanyIds],
+  );
+
+  // Compute match IDs from search text (only within visible businesses)
+  const filterMatchIds = useMemo(() => {
+    if (search.length < 2) return [];
+    const lc = search.toLowerCase();
+    const ids: string[] = [];
+    for (const biz of visibleBusinesses) {
+      const items = (biz as Business & { progressItems?: { id: string; title?: string; content: string; stage: string }[] }).progressItems ?? [];
+      for (const item of items) {
+        if (!visibleStages.has(item.stage)) continue;
+        if (
+          (item.title ?? "").toLowerCase().includes(lc) ||
+          item.content.toLowerCase().includes(lc)
+        ) {
+          ids.push(item.id);
+        }
+      }
+    }
+    return ids;
+  }, [search, visibleBusinesses, visibleStages]);
+
+  // Keep ref in sync for Enter handler
+  matchIdsRef.current = filterMatchIds;
+
+  // Sync filter text to store — only when it actually changes
+  useEffect(() => {
+    const newVal = search.length >= 2 ? search : null;
+    if (filterTextRef.current !== newVal) {
+      filterTextRef.current = newVal;
+      setFilterText(newVal);
+      setMatchIndex(-1);
+    }
+  }, [search, setFilterText]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => { setFilterText(null); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const goToNextMatch = () => {
+    const ids = matchIdsRef.current;
+    if (ids.length === 0) return;
+    const next = (matchIndex + 1) % ids.length;
+    setMatchIndex(next);
+    setHighlightId(ids[next]);
+  };
+
+  // Group businesses by company, sorted by sortOrder
   const groupedData = useMemo(() => {
-    const sortedCompanies = [...companies].sort((a, b) => {
-      if (a.isKey !== b.isKey) return a.isKey ? -1 : 1;
-      return a.sortOrder - b.sortOrder;
-    });
+    const sortedCompanies = [...companies].sort(
+      (a, b) => a.sortOrder - b.sortOrder,
+    );
 
     return sortedCompanies.map((company) => ({
       company,
@@ -68,20 +187,80 @@ export default function BusinessManagementPage() {
 
   const isLoading = companiesLoading || businessesLoading;
 
+  // DnD for company reordering
+  const reorderCompanies = useReorderCompanies();
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  );
+  const [activeCompany, setActiveCompany] = useState<Company | null>(null);
+
+  const handleDragStart = (event: DragStartEvent) => {
+    const company = companies.find((c: Company) => c.id === event.active.id);
+    setActiveCompany(company ?? null);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveCompany(null);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const sortedIds = groupedData.map((g) => g.company.id);
+    const oldIndex = sortedIds.indexOf(active.id as string);
+    const newIndex = sortedIds.indexOf(over.id as string);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const reordered = [...sortedIds];
+    const [moved] = reordered.splice(oldIndex, 1);
+    reordered.splice(newIndex, 0, moved);
+
+    reorderCompanies.mutate(reordered);
+  };
+
   return (
     <div className="flex h-[calc(100vh-3.5rem)] flex-col">
       {/* Toolbar */}
       <div className="shrink-0 flex items-center gap-3 border-b border-[var(--border)] px-4 py-3">
         <h1 className="text-lg font-bold">사업관리</h1>
 
-        <input
-          type="search"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="기업 및 사업 검색..."
-          aria-label="기업 및 사업 검색"
-          className="h-8 w-64 rounded-md border border-[var(--border)] bg-[var(--muted)] px-3 text-sm outline-none focus:ring-2 focus:ring-[var(--ring)]"
-        />
+        <div className="relative flex items-center gap-2">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && filterMatchIds.length > 0) {
+                e.preventDefault();
+                goToNextMatch();
+              }
+            }}
+            placeholder="카드 필터링... (Enter로 이동)"
+            aria-label="카드 필터링"
+            className={`h-8 w-64 rounded-md border bg-[var(--muted)] px-3 pr-8 text-sm outline-none focus:ring-2 focus:ring-[var(--ring)] transition-colors ${
+              search.length >= 2
+                ? "border-[var(--primary)] bg-[var(--primary)]/5"
+                : "border-[var(--border)]"
+            }`}
+          />
+          {search && (
+            <button
+              onClick={() => setSearch("")}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+              title="필터 해제"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+
+        {search.length >= 2 && (
+          <span className="text-xs text-[var(--primary)] font-medium tabular-nums">
+            {filterMatchIds.length === 0
+              ? "결과 없음"
+              : matchIndex >= 0
+                ? `(${matchIndex + 1}/${filterMatchIds.length})`
+                : `${filterMatchIds.length}건`}
+          </span>
+        )}
 
         <label className="flex items-center gap-1.5 text-sm cursor-pointer">
           <input
@@ -119,16 +298,22 @@ export default function BusinessManagementPage() {
 
         {!isLoading && groupedData.length === 0 && (
           <div className="flex flex-col items-center justify-center p-16 text-center">
-            <p className="text-lg font-medium">등록된 기업이 없습니다</p>
-            <p className="mt-1 text-sm text-[var(--muted-foreground)]">
-              첫 번째 기업을 생성하여 시작하세요.
+            <p className="text-lg font-medium">
+              {showKeyOnly ? "중요 기업으로 등록된 기업이 없습니다" : "등록된 기업이 없습니다"}
             </p>
-            <button
-              onClick={() => setShowNewCompany(true)}
-              className="mt-4 rounded-md bg-[var(--primary)] px-4 py-2 text-sm text-[var(--primary-foreground)] hover:opacity-90"
-            >
-              + 새 기업
-            </button>
+            <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+              {showKeyOnly
+                ? "기업 목록에서 ★를 눌러 중요 기업으로 지정하세요."
+                : "첫 번째 기업을 생성하여 시작하세요."}
+            </p>
+            {!showKeyOnly && (
+              <button
+                onClick={() => setShowNewCompany(true)}
+                className="mt-4 rounded-md bg-[var(--primary)] px-4 py-2 text-sm text-[var(--primary-foreground)] hover:opacity-90"
+              >
+                + 새 기업
+              </button>
+            )}
           </div>
         )}
 
@@ -137,50 +322,95 @@ export default function BusinessManagementPage() {
           {/* Stage column headers */}
           {groupedData.length > 0 && (
             <div className="sticky top-0 z-10 flex border-b border-[var(--border)] bg-[var(--background)]">
-              <div className="w-[280px] shrink-0 border-r border-[var(--border)] px-4 py-2">
+              <div className="sticky left-0 z-20 w-[280px] shrink-0 border-r border-[var(--border)] bg-[var(--background)] px-4 py-2">
                 <span className="text-sm font-semibold text-[var(--muted-foreground)]">
                   사업 정보
                 </span>
               </div>
-              {STAGE_LABELS.map((label) => (
-                <div
-                  key={label}
-                  className="w-[300px] shrink-0 border-r border-[var(--border)] px-2 py-2"
-                >
-                  <span className="text-xs font-semibold text-[var(--muted-foreground)] uppercase">
-                    {label}
-                  </span>
-                </div>
-              ))}
+              {STAGES_CONFIG.map(({ key, label }) => {
+                const active = visibleStages.has(key);
+                return (
+                  <div
+                    key={key}
+                    onClick={() => toggleStage(key)}
+                    className={`shrink-0 border-r border-[var(--border)] cursor-pointer select-none transition-all ${
+                      active
+                        ? "w-[300px] px-2 py-2 hover:bg-[var(--muted)]"
+                        : "w-[40px] px-1 py-2 bg-[var(--muted)] opacity-40 hover:opacity-70"
+                    }`}
+                    title={active ? `${label} 숨기기` : `${label} 표시`}
+                  >
+                    <span className={`text-xs font-semibold text-[var(--muted-foreground)] uppercase ${
+                      active ? "" : "writing-mode-vertical"
+                    }`}
+                      style={active ? undefined : { writingMode: "vertical-rl", textOrientation: "mixed" }}
+                    >
+                      {label}
+                    </span>
+                  </div>
+                );
+              })}
             </div>
           )}
 
-          {groupedData.map(({ company, businesses: bizList }) => (
-            <CompanyGroupRow
-              key={company.id}
-              company={company}
-              businessCount={bizList.length}
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={groupedData.map((g) => g.company.id)}
+              strategy={verticalListSortingStrategy}
             >
-              {bizList.length === 0 && (
-                <div className="px-8 py-3 text-xs text-[var(--muted-foreground)]">
-                  등록된 사업이 없습니다.{" "}
-                  <button
-                    onClick={() => setShowNewBusiness(true)}
-                    className="text-[var(--primary)] hover:underline"
-                  >
-                    추가하기
-                  </button>
+              {groupedData.map(({ company, businesses: bizList }) => (
+                <SortableCompanyGroup key={company.id} companyId={company.id}>
+                  {(dragHandleProps) => (
+                    <CompanyGroupRow
+                      company={company}
+                      businessCount={bizList.length}
+                      dragHandleProps={dragHandleProps}
+                    >
+                      {bizList.length === 0 && (
+                        <div className="px-8 py-3 text-xs text-[var(--muted-foreground)]">
+                          등록된 사업이 없습니다.{" "}
+                          <button
+                            onClick={() => setShowNewBusiness(true)}
+                            className="text-[var(--primary)] hover:underline"
+                          >
+                            추가하기
+                          </button>
+                        </div>
+                      )}
+                      {bizList.map((biz: Business) => (
+                        <BusinessRow
+                          key={biz.id}
+                          business={{ ...biz, companyName: company.canonicalName }}
+                          onClick={() => setSelectedBusinessId(biz.id)}
+                          visibleStages={visibleStages}
+                        />
+                      ))}
+                    </CompanyGroupRow>
+                  )}
+                </SortableCompanyGroup>
+              ))}
+            </SortableContext>
+
+            <DragOverlay>
+              {activeCompany && (
+                <div className="opacity-80 rotate-1 scale-[1.02] shadow-lg rounded-md">
+                  <div className="flex items-center gap-2 bg-[var(--muted)] border border-[var(--border)] rounded-md px-4 py-2">
+                    <span className="text-lg text-yellow-500">
+                      {activeCompany.isKey ? "★" : ""}
+                    </span>
+                    <span className="font-semibold text-sm">
+                      {activeCompany.canonicalName}
+                    </span>
+                  </div>
                 </div>
               )}
-              {bizList.map((biz: Business) => (
-                <BusinessRow
-                  key={biz.id}
-                  business={{ ...biz, companyName: company.canonicalName }}
-                  onClick={() => setSelectedBusinessId(biz.id)}
-                />
-              ))}
-            </CompanyGroupRow>
-          ))}
+            </DragOverlay>
+          </DndContext>
         </div>
       </div>
 

--- a/src/components/business-table/business-row.tsx
+++ b/src/components/business-table/business-row.tsx
@@ -18,9 +18,10 @@ interface BusinessRowProps {
     progressItems?: ProgressItem[];
   };
   onClick: () => void;
+  visibleStages?: Set<string>;
 }
 
-export function BusinessRow({ business, onClick }: BusinessRowProps) {
+export function BusinessRow({ business, onClick, visibleStages }: BusinessRowProps) {
   const [selectedBlock, setSelectedBlock] = useState<ProgressItem | null>(null);
 
   return (
@@ -28,7 +29,7 @@ export function BusinessRow({ business, onClick }: BusinessRowProps) {
       <div className="flex items-stretch border-b border-[var(--border)] hover:bg-[var(--accent)]/50 transition-colors">
         {/* Fixed left column — 사업명 + 고객사명 + 공개여부 + 규모 */}
         <div
-          className="flex min-w-[280px] w-[280px] shrink-0 flex-col justify-center gap-1 border-r border-[var(--border)] px-4 py-3 cursor-pointer"
+          className="sticky left-0 z-[5] flex min-w-[280px] w-[280px] shrink-0 flex-col justify-center gap-1 border-r border-[var(--border)] bg-[var(--background)] px-4 py-3 cursor-pointer"
           onClick={onClick}
         >
           {/* 사업명 (크게) */}
@@ -65,6 +66,7 @@ export function BusinessRow({ business, onClick }: BusinessRowProps) {
           businessId={business.id}
           progressItems={(business.progressItems ?? []) as ProgressItem[]}
           onBlockClick={(item) => setSelectedBlock(item)}
+          visibleStages={visibleStages}
         />
       </div>
 

--- a/src/components/progress-blocks/mini-block.tsx
+++ b/src/components/progress-blocks/mini-block.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
+import { useUIStore } from "@/stores/ui-store";
 import type { Stage } from "@/types";
 
 const STAGE_COLORS: Record<Stage, string> = {
@@ -23,22 +25,70 @@ interface MiniBlockProps {
 }
 
 export function MiniBlock({
+  id,
   title,
   content,
   stage,
   date,
-  createdAt,
   onClick,
 }: MiniBlockProps) {
   const displayDate = date || "";
+  const ref = useRef<HTMLDivElement>(null);
+  const [visited, setVisited] = useState(false);
+
+  const highlightId = useUIStore((s) => s.searchHighlightId);
+  const setHighlightId = useUIStore((s) => s.setSearchHighlightId);
+  const filterText = useUIStore((s) => s.searchFilterText);
+
+  const isCurrent = highlightId === id;
+
+  // Scroll into view when this card becomes the current target
+  useEffect(() => {
+    if (isCurrent) {
+      setVisited(true);
+      setTimeout(() => {
+        ref.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+      }, 100);
+    }
+  }, [isCurrent]);
+
+  // Clear visited state when filter text changes (new search)
+  useEffect(() => {
+    setVisited(false);
+  }, [filterText]);
+
+  const handleMouseEnter = () => {
+    if (visited && !isCurrent) {
+      setVisited(false);
+      setHighlightId(null);
+    }
+  };
+
+  const hasHighlight = isCurrent || visited;
+
+  // Determine if dimmed by filter (highlighted cards are never dimmed)
+  const searchText = filterText?.toLowerCase() ?? null;
+  const isDimmed =
+    !hasHighlight &&
+    searchText !== null &&
+    !(title ?? "").toLowerCase().includes(searchText) &&
+    !content.toLowerCase().includes(searchText);
+
+  const borderClass = isCurrent
+    ? "border-[3px] border-blue-500 border-l-blue-500"
+    : visited
+      ? "border-[3px] border-red-500 border-l-red-500"
+      : "border border-[var(--border)]";
 
   return (
     <div
+      ref={ref}
       onClick={(e) => {
         e.stopPropagation();
         onClick?.();
       }}
-      className={`cursor-pointer rounded-md border border-[var(--border)] border-l-2 ${STAGE_COLORS[stage]} bg-[var(--background)] px-3 py-2.5 text-sm shadow-sm hover:shadow-md transition-all`}
+      onMouseEnter={handleMouseEnter}
+      className={`cursor-pointer rounded-md border-l-2 ${STAGE_COLORS[stage]} bg-[var(--background)] px-3 py-2.5 text-sm shadow-sm hover:shadow-md transition-all ${borderClass} ${isDimmed ? "opacity-25" : ""}`}
       title={title ? `${title}\n${content}` : content}
     >
       {title && <p className="font-semibold text-[var(--foreground)] whitespace-pre-wrap break-words">{title}</p>}

--- a/src/components/progress-blocks/stage-row-dnd.tsx
+++ b/src/components/progress-blocks/stage-row-dnd.tsx
@@ -135,9 +135,10 @@ interface StageRowDndProps {
   businessId: string;
   progressItems: ProgressItem[];
   onBlockClick?: (item: ProgressItem) => void;
+  visibleStages?: Set<string>;
 }
 
-export function StageRowDnd({ businessId, progressItems, onBlockClick }: StageRowDndProps) {
+export function StageRowDnd({ businessId, progressItems, onBlockClick, visibleStages }: StageRowDndProps) {
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor),
@@ -209,15 +210,36 @@ export function StageRowDnd({ businessId, progressItems, onBlockClick }: StageRo
       onDragEnd={handleDragEnd}
     >
       <div className="flex">
-        {STAGES.map((stage) => (
-          <DroppableStage
-            key={stage}
-            stage={stage}
-            items={itemsByStage[stage]}
-            businessId={businessId}
-            onBlockClick={onBlockClick}
-          />
-        ))}
+        {STAGES.map((stage) => {
+          if (visibleStages && !visibleStages.has(stage)) {
+            const count = (itemsByStage[stage] ?? []).length;
+            return (
+              <div key={stage} className="w-[40px] shrink-0 border-r border-[var(--border)] flex flex-col items-center gap-1 py-2">
+                {(itemsByStage[stage] ?? []).slice(0, 5).map((item) => (
+                  <div
+                    key={item.id}
+                    className="w-5 h-1.5 rounded-full bg-[var(--muted-foreground)] opacity-25"
+                    title={item.title || item.content}
+                  />
+                ))}
+                {count > 5 && (
+                  <span className="text-[8px] text-[var(--muted-foreground)] opacity-40">
+                    +{count - 5}
+                  </span>
+                )}
+              </div>
+            );
+          }
+          return (
+            <DroppableStage
+              key={stage}
+              stage={stage}
+              items={itemsByStage[stage]}
+              businessId={businessId}
+              onBlockClick={onBlockClick}
+            />
+          );
+        })}
       </div>
 
       <DragOverlay>

--- a/src/components/search/search-overlay.tsx
+++ b/src/components/search/search-overlay.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useUIStore } from "@/stores/ui-store";
 import type { SearchResults } from "@/types";
 
 interface SearchOverlayProps {
@@ -11,6 +12,7 @@ interface SearchOverlayProps {
 
 export function SearchOverlay({ open, onClose }: SearchOverlayProps) {
   const [query, setQuery] = useState("");
+  const setHighlightId = useUIStore((s) => s.setSearchHighlightId);
 
   const { data } = useQuery<{ data: SearchResults; total: number }>({
     queryKey: ["search", query],
@@ -36,6 +38,12 @@ export function SearchOverlay({ open, onClose }: SearchOverlayProps) {
       return () => document.removeEventListener("keydown", handleKeyDown);
     }
   }, [open, handleKeyDown]);
+
+  // Navigate to a specific card by id (scroll + red highlight)
+  const goToCard = (itemId: string) => {
+    setHighlightId(itemId);
+    onClose();
+  };
 
   if (!open) return null;
 
@@ -75,7 +83,7 @@ export function SearchOverlay({ open, onClose }: SearchOverlayProps) {
                     key={c.id}
                     title={(c as unknown as { canonicalName: string }).canonicalName}
                     subtitle="기업"
-                    href={`/business`}
+                    href="/business"
                     onClose={onClose}
                   />
                 ))}
@@ -89,7 +97,7 @@ export function SearchOverlay({ open, onClose }: SearchOverlayProps) {
                     key={b.id}
                     title={b.name}
                     subtitle={`사업 · ${(b as unknown as { company?: { canonicalName: string } }).company?.canonicalName ?? ""}`}
-                    href={`/business`}
+                    href="/business"
                     onClose={onClose}
                   />
                 ))}
@@ -103,7 +111,7 @@ export function SearchOverlay({ open, onClose }: SearchOverlayProps) {
                     key={a.id}
                     title={(a as unknown as { content: string }).content}
                     subtitle="주간 액션"
-                    href={`/weekly`}
+                    href="/weekly"
                     onClose={onClose}
                   />
                 ))}
@@ -117,8 +125,7 @@ export function SearchOverlay({ open, onClose }: SearchOverlayProps) {
                     key={p.id}
                     title={p.content}
                     subtitle={`진행 · ${p.stage}`}
-                    href={`/business`}
-                    onClose={onClose}
+                    onClick={() => goToCard(p.id)}
                   />
                 ))}
               </ResultSection>
@@ -131,7 +138,7 @@ export function SearchOverlay({ open, onClose }: SearchOverlayProps) {
                     key={n.id}
                     title={n.title ?? n.body.slice(0, 60)}
                     subtitle="메모"
-                    href={`/business`}
+                    href="/business"
                     onClose={onClose}
                   />
                 ))}
@@ -165,13 +172,29 @@ function ResultItem({
   title,
   subtitle,
   href,
+  onClick,
   onClose,
 }: {
   title: string;
   subtitle: string;
-  href: string;
-  onClose: () => void;
+  href?: string;
+  onClick?: () => void;
+  onClose?: () => void;
 }) {
+  if (onClick) {
+    return (
+      <button
+        onClick={onClick}
+        className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm text-left hover:bg-[var(--muted)] transition-colors"
+      >
+        <div className="flex-1 min-w-0">
+          <p className="truncate font-medium">{title}</p>
+          <p className="text-xs text-[var(--muted-foreground)]">{subtitle}</p>
+        </div>
+      </button>
+    );
+  }
+
   return (
     <a
       href={href}

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -7,6 +7,12 @@ interface UIState {
   toggleSidebar: () => void;
   toggleMeetingMode: () => void;
   setMeetingMode: (active: boolean) => void;
+  // Search highlight: scroll to & red-border a specific card
+  searchHighlightId: string | null;
+  setSearchHighlightId: (id: string | null) => void;
+  // Search filter: dim all cards not matching this text
+  searchFilterText: string | null;
+  setSearchFilterText: (text: string | null) => void;
 }
 
 export const useUIStore = create<UIState>()(
@@ -19,6 +25,10 @@ export const useUIStore = create<UIState>()(
       toggleMeetingMode: () =>
         set((state) => ({ meetingModeActive: !state.meetingModeActive })),
       setMeetingMode: (active) => set({ meetingModeActive: active }),
+      searchHighlightId: null,
+      setSearchHighlightId: (id) => set({ searchHighlightId: id }),
+      searchFilterText: null,
+      setSearchFilterText: (text) => set({ searchFilterText: text }),
     }),
     {
       name: "meeting-minutes-ui",


### PR DESCRIPTION
## Summary
- **글로벌 검색 (Cmd+K)**: 진행 항목 클릭 시 해당 카드로 스크롤 + 파란색 테두리 하이라이트, 방문한 카드는 빨간색 테두리, 마우스 올리면 페이드
- **로컬 검색 (필터링)**: 검색어 미매칭 카드 흐리게 표시, Enter로 매칭 카드 순회 + (n/N) 카운터 표시
- **스테이지 토글**: 스테이지 헤더 클릭으로 컬럼 접기/펼치기 (접힌 상태 40px, 카드 개수 pill 인디케이터 표시)
- **검색 범위**: 보이는 스테이지 + 중요기업 필터 반영, 빈 상태 메시지 분기 처리

## Changed files
- `src/stores/ui-store.ts` — searchHighlightId, searchFilterText 상태 추가
- `src/components/progress-blocks/mini-block.tsx` — 하이라이트/딤밍/스크롤 로직
- `src/components/search/search-overlay.tsx` — 진행항목 goToCard 네비게이션
- `src/app/business/page.tsx` — 로컬 필터링, 매치 네비게이션, 스테이지 토글, DnD 회사 정렬
- `src/components/business-table/business-row.tsx` — visibleStages prop 전달
- `src/components/progress-blocks/stage-row-dnd.tsx` — 접힌 스테이지 렌더링

## Test plan
- [ ] Cmd+K로 글로벌 검색 후 진행 항목 클릭 → 카드로 스크롤 및 파란 테두리 확인
- [ ] 로컬 검색 입력 → 비매칭 카드 흐림 처리 확인
- [ ] Enter 키로 매칭 카드 순회 및 (n/N) 카운터 확인
- [ ] 스테이지 헤더 클릭 → 컬럼 접기/펼치기 확인
- [ ] 중요기업만 체크 시 빈 상태 메시지 분기 확인
- [ ] 접힌 스테이지에서 pill 인디케이터 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)