### PR TITLE
fix: 새 기업 생성 시 별칭 입력 제거

### DIFF
--- a/src/components/business-table/new-company-dialog.tsx
+++ b/src/components/business-table/new-company-dialog.tsx
@@ -10,25 +10,18 @@ interface NewCompanyDialogProps {
 
 export function NewCompanyDialog({ open, onClose }: NewCompanyDialogProps) {
   const [name, setName] = useState("");
-  const [aliasInput, setAliasInput] = useState("");
   const createCompany = useCreateCompany();
 
   if (!open) return null;
-
-  const aliases = aliasInput
-    .split(",")
-    .map((a) => a.trim())
-    .filter(Boolean);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) return;
     createCompany.mutate(
-      { canonicalName: name.trim(), aliases },
+      { canonicalName: name.trim() },
       {
         onSuccess: () => {
           setName("");
-          setAliasInput("");
           onClose();
         },
       },
@@ -55,17 +48,6 @@ export function NewCompanyDialog({ open, onClose }: NewCompanyDialogProps) {
             className="mt-1 w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-[var(--ring)]"
             autoFocus
             required
-          />
-        </label>
-
-        <label className="mt-4 block text-sm font-medium">
-          별칭 (쉼표로 구분)
-          <input
-            type="text"
-            value={aliasInput}
-            onChange={(e) => setAliasInput(e.target.value)}
-            placeholder="예: ABC Corp, ABC"
-            className="mt-1 w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-[var(--ring)]"
           />
         </label>
 


### PR DESCRIPTION
## Summary
- 새 기업 생성 다이얼로그에서 별칭(alias) 입력 필드 제거
- 대표 이름만 입력하도록 단순화

## Test plan
- [ ] +기업 버튼 → 대표 이름만 입력란 확인
- [ ] 기업 생성 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)