### PR TITLE
fix: 종료된 사업 카드 검색에서 제외

### DIFF
--- a/src/app/business/page.tsx
+++ b/src/app/business/page.tsx
@@ -130,6 +130,7 @@ export default function BusinessManagementPage() {
     const lc = search.toLowerCase();
     const ids: string[] = [];
     for (const biz of visibleBusinesses) {
+      if (biz.isArchived) continue;
       const items = (biz as Business & { progressItems?: { id: string; title?: string; content: string; stage: string }[] }).progressItems ?? [];
       for (const item of items) {
         if (!visibleStages.has(item.stage)) continue;


### PR DESCRIPTION
## Summary
- 종료(archived)된 사업의 카드는 로컬 검색/필터링에서 제외

## Test plan
- [ ] 사업 종료 후 카드 필터링 검색 시 해당 사업 카드가 매칭되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)