### PR TITLE
docs: 문서 최신화 — 주간회의 테이블 + FunnelNo.

### DIFF
--- a/specs/feat/001-biz-meeting-ops/contracts/api-contracts.md
+++ b/specs/feat/001-biz-meeting-ops/contracts/api-contracts.md
@@ -107,8 +107,9 @@ Get business with progress items grouped by stage.
 ### PUT /api/businesses/:id
 Update business.
 
-**Body**: `{ name?, visibility?, scale?, timing_text?, timing_start?, timing_end?, current_stage?, assigned_to?, sort_order?, lock_version }`
+**Body**: `{ name?, visibility?, scale?, timing_text?, timing_start?, timing_end?, current_stage?, assigned_to?, sort_order?, funnelNumbers?, lock_version }`
 **Response**: `{ data: Business }` | `409 Conflict`
+**Notes**: When the update payload contains **only** `funnelNumbers` (no other fields changed), the `lock_version` check is skipped to allow lightweight inline edits without conflict errors.
 
 ### POST /api/businesses/:id/archive
 ### POST /api/businesses/:id/restore
@@ -163,6 +164,13 @@ current week only)
 Get or create the current week's cycle.
 
 **Response**: `{ data: WeeklyCycle }`
+
+### POST /api/weekly-cycles
+Upsert a weekly cycle (create if not exists for the given year + week_number).
+
+**Body**: `{ year, week_number, start_date, end_date }`
+**Response**: `200 { data: WeeklyCycle }` (existing) or `201 { data: WeeklyCycle }` (created)
+**Notes**: Used by auto-create logic to ensure cycles exist for past and future weeks when navigating the monthly view.
 
 ---
 

--- a/specs/feat/001-biz-meeting-ops/data-model.md
+++ b/specs/feat/001-biz-meeting-ops/data-model.md
@@ -124,6 +124,7 @@ flag is a favorite marker only and does not affect sort order.
 | created_at     | TIMESTAMPTZ  | NOT NULL, DEFAULT NOW()          |
 | updated_at     | TIMESTAMPTZ  | NOT NULL, DEFAULT NOW()          |
 | lock_version   | INT          | NOT NULL, DEFAULT 1              |
+| funnelNumbers  | JSONB        | nullable, DEFAULT '{}' (keyed by stage name, e.g. {"funnel":"F-001","pipeline":"P-012"}) |
 
 **Stage enum**: `inbound`, `funnel`, `pipeline`, `proposal`, `contract`,
 `build`, `maintenance`

--- a/specs/feat/001-biz-meeting-ops/spec.md
+++ b/specs/feat/001-biz-meeting-ops/spec.md
@@ -610,6 +610,23 @@ The service has the following menu structure:
   dragging the bottom-right corner (min 540×400px). Textarea fills
   available space. Size resets when opening a different card.
 
+### Session 2026-03-25
+
+- Q: Weekly meeting page layout redesign? → A: Redesigned as a company × week
+  table (similar to Excel). Monthly navigation with a month picker, inline
+  Tiptap rich text editing per cell, auto-create weekly cycles for past and
+  future weeks on demand, and week column toggle (collapse/expand individual
+  week columns).
+- Q: FunnelNo. per stage per business? → A: Free text identifier displayed
+  above progress cards for each stage cell. Double-click to edit inline,
+  auto-saves. Stored as JSONB field (`funnelNumbers`) on the Business entity
+  (keyed by stage name).
+- Q: Block detail modal — weekly actions panel? → A: The block detail modal
+  now shows weekly actions (previous week / this week / next week) for the
+  same company in the right panel below the calendar section.
+- Q: Excel source files in repo? → A: `.xlsx` and `.xls` files added to
+  `.gitignore` to prevent accidental commits of data files.
+
 ## Assumptions
 
 - The service targets a small-to-medium internal team (up to ~50

--- a/specs/feat/001-biz-meeting-ops/tasks.md
+++ b/specs/feat/001-biz-meeting-ops/tasks.md
@@ -328,6 +328,24 @@
 
 ---
 
+## Phase 17: Weekly Table Redesign + FunnelNo. (2026-03-25)
+
+**Purpose**: Weekly meeting page redesign as company × week table with monthly navigation, inline editing, and FunnelNo. per stage
+
+### Completed Tasks
+
+- [x] T122 [US3] Weekly meeting table redesign — company × week layout, monthly navigation with month picker in src/app/weekly/page.tsx
+- [x] T123 [US3] Inline Tiptap rich text editor for weekly cells in src/components/weekly-meeting/tiptap-cell-editor.tsx
+- [x] T124 [US3] Week column toggle — collapse/expand individual week columns in src/app/weekly/page.tsx
+- [x] T125 [US3] Auto-create weekly cycles via POST /api/weekly-cycles (upsert for past/future weeks) in src/app/api/weekly-cycles/route.ts
+- [x] T126 [US3] useWeeklyActionsMultiCycle hook for monthly data fetch (all cycles in visible month) in src/hooks/use-weekly-actions.ts
+- [x] T127 [US2] Block detail modal weekly actions panel — shows prev/this/next week actions for the same company in the right panel below calendar in src/components/progress-blocks/block-detail.tsx
+- [x] T128 [US1] FunnelNo. per stage on business — JSONB field, double-click inline edit, auto-save (skips lockVersion for funnelNumbers-only updates) in src/components/business-table/funnel-number.tsx, src/app/api/businesses/[id]/route.ts
+- [x] T129 Excel data import script for weekly meeting data in prisma/import-weekly.ts
+- [x] T130 .gitignore update — added *.xlsx and *.xls patterns to prevent accidental data file commits
+
+---
+
 ## Dependencies & Execution Order
 
 ### Phase Dependencies
@@ -414,4 +432,4 @@ After Phase 2 (Foundational) completes:
 - Each user story should be independently completable and testable
 - Commit after each task or logical group
 - Stop at any checkpoint to validate story independently
-- Total tasks: 109
+- Total tasks: 118


### PR DESCRIPTION
## Summary
- Phase 17 스펙 문서 업데이트: 주간회의 테이블 재설계 (기업×주차), 월간 네비게이션, 인라인 Tiptap 편집
- FunnelNo. JSONB 필드 데이터 모델 추가 및 API 계약 업데이트
- POST /api/weekly-cycles upsert 엔드포인트 추가
- tasks.md에 Phase 17 (T122–T130) 완료 태스크 기록

## Test plan
- [ ] spec.md Clarifications Session 2026-03-25 섹션 확인
- [ ] data-model.md Business 엔티티에 funnelNumbers JSONB 필드 확인
- [ ] api-contracts.md POST /api/weekly-cycles 엔드포인트 확인
- [ ] api-contracts.md PUT /api/businesses/:id funnelNumbers 지원 확인
- [ ] tasks.md Phase 17 태스크 T122–T130 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)