### PR TITLE
feat: FunnelNo. 스테이지별 식별번호 (v2)

### DIFF
--- a/prisma/migrations/20260325010000_add_funnel_numbers/migration.sql
+++ b/prisma/migrations/20260325010000_add_funnel_numbers/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "businesses" ADD COLUMN "funnel_numbers" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -149,6 +149,7 @@ model Business {
   timingText   String?    @map("timing_text")
   timingStart  DateTime?  @map("timing_start") @db.Date
   timingEnd    DateTime?  @map("timing_end") @db.Date
+  funnelNumbers Json?     @map("funnel_numbers") @db.JsonB
   currentStage Stage?     @map("current_stage")
   assignedToId String?    @map("assigned_to")
   isArchived   Boolean    @default(false) @map("is_archived")

--- a/src/app/api/businesses/[id]/route.ts
+++ b/src/app/api/businesses/[id]/route.ts
@@ -1,8 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { createAuditLog } from "@/lib/audit";
 import { createVersionSnapshot } from "@/lib/version";
 import { checkLockVersion, ConflictError, conflictResponse } from "@/lib/conflict";
+
+const VALID_STAGES = new Set(["inbound", "funnel", "pipeline", "proposal", "contract", "build", "maintenance"]);
+
+const funnelNumbersSchema = z.record(z.string(), z.string()).refine(
+  (obj) => Object.keys(obj).every((k) => VALID_STAGES.has(k)),
+  { message: "Keys must be valid stage names" },
+);
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -59,7 +67,20 @@ export async function PUT(request: NextRequest, context: Params) {
       throw e;
     }
 
-    const data: Record<string, unknown> = { lockVersion: { increment: 1 } };
+    // Validate funnelNumbers if present
+    if (updateData.funnelNumbers !== undefined && updateData.funnelNumbers !== null) {
+      const parsed = funnelNumbersSchema.safeParse(updateData.funnelNumbers);
+      if (!parsed.success) {
+        return NextResponse.json(
+          { error: "VALIDATION", message: "Invalid funnelNumbers: keys must be valid stages, values must be strings" },
+          { status: 400 },
+        );
+      }
+    }
+
+    const isFunnelOnly = Object.keys(updateData).length === 1 && updateData.funnelNumbers !== undefined;
+    const data: Record<string, unknown> = isFunnelOnly ? {} : { lockVersion: { increment: 1 } };
+    if (updateData.funnelNumbers !== undefined) data.funnelNumbers = updateData.funnelNumbers;
     if (updateData.name !== undefined) data.name = updateData.name.trim();
     if (updateData.embargoName !== undefined) data.embargoName = updateData.embargoName;
     if (updateData.visibility !== undefined) data.visibility = updateData.visibility;

--- a/src/components/business-table/business-row.tsx
+++ b/src/components/business-table/business-row.tsx
@@ -15,11 +15,13 @@ interface BusinessRowProps {
     timingText: string | null;
     timingStart?: string | null;
     timingEnd?: string | null;
+    funnelNumbers?: Record<string, string> | null;
     currentStage: Stage | null;
     assignedTo: string | null;
     isArchived?: boolean;
     companyName?: string;
     progressItems?: ProgressItem[];
+    lockVersion?: number;
   };
   onClick: () => void;
   visibleStages?: Set<string>;
@@ -104,6 +106,8 @@ export function BusinessRow({ business, onClick, visibleStages, highlighted }: B
             progressItems={(business.progressItems ?? []) as ProgressItem[]}
             onBlockClick={(item) => setSelectedBlock(item)}
             visibleStages={visibleStages}
+            funnelNumbers={business.funnelNumbers ?? undefined}
+            lockVersion={business.lockVersion}
           />
         )}
       </div>

--- a/src/components/progress-blocks/stage-row-dnd.tsx
+++ b/src/components/progress-blocks/stage-row-dnd.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -21,6 +21,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { useDroppable } from "@dnd-kit/core";
 import { MiniBlock } from "./mini-block";
 import { useMoveProgressItem, useCreateProgressItem } from "@/hooks/use-progress-items";
+import { useUpdateBusiness } from "@/hooks/use-businesses";
 import type { ProgressItem, Stage } from "@/types";
 
 const STAGES: Stage[] = [
@@ -71,16 +72,41 @@ function DroppableStage({
   items,
   businessId,
   onBlockClick,
+  funnelNo,
+  onFunnelNoChange,
 }: {
   stage: Stage;
   items: ProgressItem[];
   businessId: string;
   onBlockClick?: (item: ProgressItem) => void;
+  funnelNo?: string;
+  onFunnelNoChange?: (stage: Stage, value: string) => void;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: `stage-${stage}`, data: { stage } });
   const [showAdd, setShowAdd] = useState(false);
   const [newTitle, setNewTitle] = useState("");
   const createItem = useCreateProgressItem();
+
+  const [editingFunnel, setEditingFunnel] = useState(false);
+  const [funnelValue, setFunnelValue] = useState(funnelNo ?? "");
+  const funnelInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!editingFunnel) setFunnelValue(funnelNo ?? "");
+  }, [funnelNo, editingFunnel]);
+
+  const handleFunnelSave = () => {
+    setEditingFunnel(false);
+    const trimmed = funnelValue.trim();
+    if (trimmed !== (funnelNo ?? "")) {
+      onFunnelNoChange?.(stage, trimmed);
+    }
+  };
+
+  const handleFunnelCancel = () => {
+    setEditingFunnel(false);
+    setFunnelValue(funnelNo ?? "");
+  };
 
   const handleAdd = () => {
     if (!newTitle.trim()) return;
@@ -98,6 +124,41 @@ function DroppableStage({
       }`}
       onClick={(e) => e.stopPropagation()}
     >
+      {/* FunnelNo. display */}
+      <div className="min-h-[18px] -mb-1">
+        {editingFunnel ? (
+          <input
+            ref={funnelInputRef}
+            type="text"
+            value={funnelValue}
+            onChange={(e) => setFunnelValue(e.target.value)}
+            onBlur={handleFunnelSave}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleFunnelSave();
+              if (e.key === "Escape") handleFunnelCancel();
+            }}
+            className="w-full border border-transparent bg-transparent px-0 py-0 text-xs font-bold font-mono text-[var(--primary)] outline-none focus:border-[var(--primary)]/30"
+            autoFocus
+          />
+        ) : (
+          <div
+            className="group cursor-default"
+            onDoubleClick={() => {
+              setEditingFunnel(true);
+              setTimeout(() => funnelInputRef.current?.focus(), 0);
+            }}
+          >
+            {funnelNo ? (
+              <span className="text-xs font-bold font-mono text-[var(--primary)]">{funnelNo}</span>
+            ) : (
+              <span className="text-xs font-bold font-mono text-transparent group-hover:text-[var(--muted-foreground)]/30 transition-colors select-none">
+                No.
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
       <SortableContext items={items.map((i) => i.id)} strategy={verticalListSortingStrategy}>
         {items.map((item) => (
           <SortableBlock key={item.id} item={item} onClick={() => onBlockClick?.(item)} />
@@ -136,15 +197,35 @@ interface StageRowDndProps {
   progressItems: ProgressItem[];
   onBlockClick?: (item: ProgressItem) => void;
   visibleStages?: Set<string>;
+  funnelNumbers?: Record<string, string>;
+  lockVersion?: number;
 }
 
-export function StageRowDnd({ businessId, progressItems, onBlockClick, visibleStages }: StageRowDndProps) {
+export function StageRowDnd({ businessId, progressItems, onBlockClick, visibleStages, funnelNumbers, lockVersion }: StageRowDndProps) {
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor),
   );
   const moveItem = useMoveProgressItem();
+  const updateBusiness = useUpdateBusiness();
   const [activeItem, setActiveItem] = useState<ProgressItem | null>(null);
+
+  const handleFunnelNoChange = useCallback(
+    (stage: Stage, value: string) => {
+      const updated = { ...(funnelNumbers ?? {}) };
+      if (value === "") {
+        delete updated[stage];
+      } else {
+        updated[stage] = value;
+      }
+      updateBusiness.mutate({
+        id: businessId,
+        funnelNumbers: Object.keys(updated).length > 0 ? updated : null,
+        lockVersion: lockVersion ?? 1,
+      });
+    },
+    [businessId, funnelNumbers, lockVersion, updateBusiness],
+  );
 
   const itemsByStage = STAGES.reduce(
     (acc, stage) => {
@@ -237,6 +318,8 @@ export function StageRowDnd({ businessId, progressItems, onBlockClick, visibleSt
               items={itemsByStage[stage]}
               businessId={businessId}
               onBlockClick={onBlockClick}
+              funnelNo={funnelNumbers?.[stage]}
+              onFunnelNoChange={handleFunnelNoChange}
             />
           );
         })}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -77,6 +77,7 @@ export interface Business {
   timingText: string | null;
   timingStart: string | null;
   timingEnd: string | null;
+  funnelNumbers: Record<string, string> | null;
   currentStage: Stage | null;
   assignedTo: string | null;
   isArchived: boolean;


### PR DESCRIPTION
## Summary
- Business 모델에 `funnelNumbers` JSONB 필드 추가 (마이그레이션 포함)
- 각 스테이지 셀 상단에 FunnelNo. 표시 (파란색 font-mono, 더블클릭으로 편집)
- blur/Enter로 저장, Esc로 취소
- Zod 유효성 검증 (키는 유효한 stage 이름, 값은 string)
- funnelNumbers만 변경 시 lockVersion 증가 생략 (다른 편집과 충돌 방지)

## Review feedback addressed (PR #146)
- Clean branch from master — PR #145 코드 포함하지 않음
- useEffect로 funnelValue 동기화 (React strict mode safe)
- 빈 값 trim 후 키 삭제 처리
- lockVersion 체크는 유지하되, funnelOnly 업데이트 시 increment 생략

## Test plan
- [ ] 스테이지 셀 상단에 "No." placeholder가 hover 시 보이는지 확인
- [ ] 더블클릭으로 FunnelNo. 입력 필드 열림 확인
- [ ] 값 입력 후 blur/Enter 시 저장 확인 (API 호출 + DB 반영)
- [ ] Esc 시 취소되고 원래 값 복원 확인
- [ ] 빈 값 입력 시 해당 stage 키 삭제 확인
- [ ] funnelNumbers만 변경 시 lockVersion이 증가하지 않는지 확인
- [ ] 잘못된 stage 키로 API 직접 호출 시 400 에러 반환 확인
- [ ] Prisma 마이그레이션 정상 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)