### PR TITLE
feat: weekly meeting table view with monthly navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 참고디자인/
+*.xlsx
+*.xls
 
 # dependencies
 node_modules/

--- a/src/app/api/weekly-actions/route.ts
+++ b/src/app/api/weekly-actions/route.ts
@@ -6,6 +6,7 @@ import { createVersionSnapshot } from "@/lib/version";
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const cycleId = searchParams.get("cycle_id");
+  const cycleIds = searchParams.get("cycle_ids"); // batch: comma-separated cycle IDs
   const companyId = searchParams.get("company_id");
   const businessId = searchParams.get("business_id");
   const assignedTo = searchParams.get("assigned_to");
@@ -13,9 +14,16 @@ export async function GET(request: NextRequest) {
   const search = searchParams.get("search") ?? "";
   const includeArchived = searchParams.get("include_archived") === "true";
 
+  // Support batch cycle_ids (comma-separated) for single-request monthly view
+  const cycleIdFilter = cycleIds
+    ? { cycleId: { in: cycleIds.split(",").filter(Boolean) } }
+    : cycleId
+      ? { cycleId }
+      : {};
+
   const where = {
     ...(includeArchived ? {} : { isArchived: false }),
-    ...(cycleId ? { cycleId } : {}),
+    ...cycleIdFilter,
     ...(companyId ? { companyId } : {}),
     ...(businessId ? { businessId } : {}),
     ...(assignedTo ? { assignedToId: assignedTo } : {}),

--- a/src/app/api/weekly-cycles/route.ts
+++ b/src/app/api/weekly-cycles/route.ts
@@ -32,8 +32,35 @@ export async function GET(request: NextRequest) {
   const cycles = await prisma.weeklyCycle.findMany({
     where,
     orderBy: [{ year: "desc" }, { weekNumber: "desc" }],
-    take: 20,
+    take: 52,
   });
 
   return NextResponse.json({ data: cycles });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { year, weekNumber } = body;
+
+    if (!year || !weekNumber) {
+      return NextResponse.json(
+        { error: "VALIDATION", message: "year and weekNumber are required" },
+        { status: 400 },
+      );
+    }
+
+    const { startDate, endDate } = getWeekDateRange(year, weekNumber);
+
+    const cycle = await prisma.weeklyCycle.upsert({
+      where: { year_weekNumber: { year, weekNumber } },
+      update: {},
+      create: { year, weekNumber, startDate, endDate },
+    });
+
+    return NextResponse.json({ data: cycle });
+  } catch (error) {
+    console.error("POST /api/weekly-cycles error:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
 }

--- a/src/app/weekly/page.tsx
+++ b/src/app/weekly/page.tsx
@@ -1,9 +1,19 @@
 "use client";
 
-import { useState, useMemo } from "react";
-import { useCurrentCycle, useWeeklyCycles, useWeeklyActions } from "@/hooks/use-weekly-actions";
+import { useState, useMemo, useCallback, useRef, useEffect } from "react";
+import DOMPurify from "dompurify";
+import {
+  useCurrentCycle,
+  useWeeklyCycles,
+  useWeeklyActions,
+  useWeeklyActionsMultiCycle,
+  useCreateWeeklyAction,
+  useUpdateWeeklyAction,
+  useEnsureCycle,
+} from "@/hooks/use-weekly-actions";
 import { useCompanies } from "@/hooks/use-companies";
-import { ActionCard } from "@/components/weekly-meeting/action-card";
+import { InlineEditor } from "@/components/editor/inline-editor";
+import { ExcelDownloadDialog } from "@/components/export/excel-download-dialog";
 import { NewActionDialog } from "@/components/weekly-meeting/new-action-dialog";
 import { CarryoverDialog } from "@/components/weekly-meeting/carryover-dialog";
 import { WeekEndActions } from "@/components/weekly-meeting/week-end-actions";
@@ -11,114 +21,482 @@ import { QuickActionsBar } from "@/components/ui/quick-actions";
 import { MeetingModeToggle } from "@/components/meeting-mode/meeting-mode-toggle";
 import { MeetingModeView } from "@/components/meeting-mode/meeting-mode-view";
 import { useUIStore } from "@/stores/ui-store";
-import { ExcelDownloadDialog } from "@/components/export/excel-download-dialog";
-import { formatWeekLabel } from "@/lib/weekly-cycle";
-import type { Company, WeeklyActionWithRelations } from "@/types";
+import { getWeeksInMonth, formatMonthLabel, formatWeekLabel } from "@/lib/weekly-cycle";
+import type { Company, WeeklyAction, WeeklyActionWithRelations } from "@/types";
 
+/* --- Status helpers --- */
+const STATUS_COLORS: Record<string, string> = {
+  scheduled: "bg-gray-400",
+  in_progress: "bg-blue-500",
+  completed: "bg-green-500",
+  on_hold: "bg-yellow-500",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  scheduled: "예정",
+  in_progress: "진행중",
+  completed: "완료",
+  on_hold: "보류",
+};
+
+function StatusBadge({ status, onClick }: { status: string; onClick?: () => void }) {
+  return (
+    <span
+      onClick={onClick}
+      className={`inline-block text-[9px] text-white px-1.5 py-0.5 rounded-full leading-none ${STATUS_COLORS[status] ?? "bg-gray-400"} ${onClick ? "cursor-pointer hover:opacity-80" : ""}`}
+    >
+      {STATUS_LABELS[status] ?? status}
+    </span>
+  );
+}
+
+/* --- MonthPicker with outside-click close --- */
+function MonthPicker({
+  year,
+  month,
+  onPrev,
+  onNext,
+  onChange,
+}: {
+  year: number;
+  month: number;
+  onPrev: () => void;
+  onNext: () => void;
+  onChange: (y: number, m: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [pickerYear, setPickerYear] = useState(year);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const months = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+  return (
+    <div ref={containerRef} className="relative flex items-center gap-1">
+      <button onClick={onPrev} className="px-2 py-1 rounded hover:bg-[var(--muted)] text-sm">
+        ←
+      </button>
+      <button
+        onClick={() => { setPickerYear(year); setOpen(!open); }}
+        className="text-sm font-medium w-24 text-center rounded hover:bg-[var(--muted)] py-1 cursor-pointer"
+      >
+        {formatMonthLabel(year, month)}
+      </button>
+      <button onClick={onNext} className="px-2 py-1 rounded hover:bg-[var(--muted)] text-sm">
+        →
+      </button>
+
+      {open && (
+        <div className="absolute top-full left-0 mt-1 z-50 rounded-lg border border-[var(--border)] bg-[var(--background)] p-3 shadow-lg w-[220px]">
+          <div className="flex items-center justify-between mb-2">
+            <button
+              onClick={() => setPickerYear(pickerYear - 1)}
+              className="text-sm px-1 hover:bg-[var(--muted)] rounded"
+            >
+              ←
+            </button>
+            <span className="text-sm font-bold">{pickerYear}년</span>
+            <button
+              onClick={() => setPickerYear(pickerYear + 1)}
+              className="text-sm px-1 hover:bg-[var(--muted)] rounded"
+            >
+              →
+            </button>
+          </div>
+          <div className="grid grid-cols-4 gap-1">
+            {months.map((m) => (
+              <button
+                key={m}
+                onClick={() => { onChange(pickerYear, m); setOpen(false); }}
+                className={`rounded px-2 py-1.5 text-xs transition-colors ${
+                  pickerYear === year && m === month
+                    ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+                    : "hover:bg-[var(--muted)]"
+                }`}
+              >
+                {m}월
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* --- Types --- */
+type MonthCycle = { year: number; weekNumber: number; weekInMonth: number; cycleId: string | null };
+type EditingCell = {
+  companyId: string;
+  cycleId: string;
+  weekYear: number;
+  weekNumber: number;
+  actionId?: string;
+  status: string;
+} | null;
+
+/* --- Company Row --- */
+function WeeklyCompanyRow({
+  company,
+  monthCycles,
+  cycleMap,
+  editingCell,
+  collapsedWeeks,
+  onStartEdit,
+  onSaveEdit,
+  onCancelEdit,
+  onStatusChange,
+  onActionStatusChange,
+}: {
+  company: Company;
+  monthCycles: MonthCycle[];
+  cycleMap: Map<string, (WeeklyAction & { company?: { id: string; canonicalName: string; isKey: boolean } })[]> | undefined;
+  editingCell: EditingCell;
+  collapsedWeeks: Set<string>;
+  onStartEdit: (companyId: string, cycleId: string | null, weekYear: number, weekNumber: number, action?: WeeklyAction) => void;
+  onSaveEdit: (html: string) => void;
+  onCancelEdit: () => void;
+  onStatusChange: (status: string) => void;
+  onActionStatusChange: (actionId: string, lockVersion: number, newStatus: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(true);
+
+  const hasContent = monthCycles.some((w) => {
+    if (!w.cycleId || !cycleMap) return false;
+    return (cycleMap.get(w.cycleId) ?? []).length > 0;
+  });
+
+  return (
+    <div className="border-b-2 border-[var(--border)]">
+      <div className="flex hover:bg-[var(--accent)]/30 transition-colors">
+        {/* Company name - sticky */}
+        <div
+          className="sticky left-0 z-[5] w-[220px] shrink-0 border-r border-[var(--border)] bg-[var(--background)] px-3 py-2.5 flex items-start gap-1.5 cursor-pointer"
+          onClick={() => setExpanded(!expanded)}
+        >
+          <span className="text-xs text-[var(--muted-foreground)] mt-0.5">
+            {expanded ? "▼" : "▶"}
+          </span>
+          {company.isKey && (
+            <span className="text-yellow-500 text-sm">★</span>
+          )}
+          <span className="text-sm font-bold truncate">
+            {company.canonicalName}
+          </span>
+          {!expanded && hasContent && (
+            <span className="text-[10px] text-[var(--muted-foreground)] ml-auto">...</span>
+          )}
+        </div>
+
+        {/* Week cells */}
+        {expanded && monthCycles.map((w) => {
+          const wKey = `${w.year}-${w.weekNumber}`;
+          const weekCollapsed = collapsedWeeks.has(wKey);
+          const cycleId = w.cycleId;
+          const cellActions = cycleId && cycleMap
+            ? cycleMap.get(cycleId) ?? []
+            : [];
+
+          if (weekCollapsed) {
+            return (
+              <div key={wKey} className="w-[40px] shrink-0 border-r border-[var(--border)] flex flex-col items-center gap-1 py-2">
+                {cellActions.slice(0, 3).map((a) => (
+                  <div key={a.id} className="w-5 h-1.5 rounded-full bg-[var(--muted-foreground)] opacity-25" />
+                ))}
+                {cellActions.length > 3 && (
+                  <span className="text-[8px] text-[var(--muted-foreground)] opacity-40">+{cellActions.length - 3}</span>
+                )}
+              </div>
+            );
+          }
+
+          return (
+            <div
+              key={wKey}
+              className="w-[320px] shrink-0 border-r border-[var(--border)] px-2 py-2 flex flex-col gap-1.5 cursor-pointer min-h-[48px]"
+              onClick={() => {
+                if (!editingCell) {
+                  onStartEdit(company.id, cycleId, w.year, w.weekNumber, undefined);
+                }
+              }}
+            >
+              {cellActions.map((action) => {
+                const isEditing = editingCell?.actionId === action.id;
+
+                return isEditing ? (
+                  <InlineEditor
+                    key={action.id}
+                    content={action.content}
+                    onSave={onSaveEdit}
+                    onCancel={onCancelEdit}
+                    status={editingCell?.status ?? action.status}
+                    onStatusChange={onStatusChange}
+                  />
+                ) : (
+                  <div
+                    key={action.id}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onStartEdit(company.id, cycleId, w.year, w.weekNumber, action);
+                    }}
+                    className="group rounded bg-[var(--muted)] px-2.5 py-1.5 text-sm font-medium cursor-pointer hover:bg-[var(--accent)] transition-colors break-words [&_p]:m-0 [&_ul]:pl-4 [&_ul]:list-disc [&_ol]:pl-4 [&_ol]:list-decimal"
+                  >
+                    <div className="flex items-center gap-1.5 mb-0.5">
+                      <StatusBadge
+                        status={action.status}
+                        onClick={() => {
+                          // Cycle through statuses on click
+                          const statuses = ["scheduled", "in_progress", "completed", "on_hold"];
+                          const idx = statuses.indexOf(action.status);
+                          const next = statuses[(idx + 1) % statuses.length];
+                          onActionStatusChange(action.id, action.lockVersion, next);
+                        }}
+                      />
+                    </div>
+                    <div
+                      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(action.content) }}
+                    />
+                  </div>
+                );
+              })}
+
+              {editingCell?.companyId === company.id &&
+               editingCell?.weekYear === w.year &&
+               editingCell?.weekNumber === w.weekNumber &&
+               !editingCell?.actionId && (
+                <InlineEditor
+                  content=""
+                  placeholder="TASK 입력..."
+                  onSave={onSaveEdit}
+                  onCancel={onCancelEdit}
+                  status={editingCell.status}
+                  onStatusChange={onStatusChange}
+                />
+              )}
+            </div>
+          );
+        })}
+
+        {/* Collapsed - empty filler */}
+        {!expanded && (
+          <div className="flex-1" />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* --- Main Page --- */
 export default function WeeklyMeetingPage() {
-  const { data: currentCycleData } = useCurrentCycle();
-  const { data: cyclesData } = useWeeklyCycles();
-  const currentCycle = currentCycleData?.data;
-  const cycles = cyclesData?.data ?? [];
-
-  const [selectedCycleId, setSelectedCycleId] = useState<string | null>(null);
-  const activeCycleId = selectedCycleId ?? currentCycle?.id ?? null;
-
-  const meetingModeActive = useUIStore((s) => s.meetingModeActive);
-  const [statusFilter, setStatusFilter] = useState<string>("");
+  const now = new Date();
+  const [viewYear, setViewYear] = useState(now.getFullYear());
+  const [viewMonth, setViewMonth] = useState(now.getMonth() + 1);
+  const [showExcelDownload, setShowExcelDownload] = useState(false);
   const [showNewAction, setShowNewAction] = useState(false);
   const [showCarryover, setShowCarryover] = useState(false);
-  const [showExcelDownload, setShowExcelDownload] = useState(false);
+  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [collapsedWeeks, setCollapsedWeeks] = useState<Set<string>>(new Set());
 
-  const { data: actionsData, isLoading: actionsLoading } = useWeeklyActions({
+  const meetingModeActive = useUIStore((s) => s.meetingModeActive);
+
+  const toggleWeek = (key: string) => {
+    setCollapsedWeeks((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  // Weeks in current month
+  const weeksInMonth = useMemo(
+    () => getWeeksInMonth(viewYear, viewMonth),
+    [viewYear, viewMonth],
+  );
+
+  // Fetch all cycles and find matching ones
+  const { data: currentCycleData } = useCurrentCycle();
+  const { data: cyclesData } = useWeeklyCycles(viewYear);
+  const currentCycle = currentCycleData?.data;
+  const allCycles = cyclesData?.data ?? [];
+
+  const monthCycles = useMemo(() => {
+    return weeksInMonth.map((w) => {
+      const cycle = allCycles.find(
+        (c) => c.year === w.year && c.weekNumber === w.weekNumber,
+      );
+      return { ...w, cycleId: cycle?.id ?? null };
+    });
+  }, [weeksInMonth, allCycles]);
+
+  const cycleIds = useMemo(
+    () => monthCycles.filter((c) => c.cycleId).map((c) => c.cycleId!),
+    [monthCycles],
+  );
+
+  // Fetch actions for all cycles in the month (single batch request)
+  const { data: actionsData, isLoading } = useWeeklyActionsMultiCycle(cycleIds);
+  const actions = (actionsData?.data ?? []) as (WeeklyAction & {
+    company?: { id: string; canonicalName: string; isKey: boolean };
+  })[];
+
+  // For meeting mode - get current cycle's actions
+  const activeCycleId = currentCycle?.id ?? null;
+  const { data: currentActionsData } = useWeeklyActions({
     cycleId: activeCycleId ?? undefined,
     status: statusFilter || undefined,
   });
+  const currentActions = (currentActionsData?.data ?? []) as WeeklyActionWithRelations[];
+
+  // Companies
   const { data: companiesData } = useCompanies();
+  const companies = (companiesData?.data ?? []) as Company[];
 
-  const actions = (actionsData?.data ?? []) as WeeklyActionWithRelations[];
-  const companies = companiesData?.data ?? [];
+  // Group actions by company + cycle, with optional status filter
+  const { companyRows, actionMap } = useMemo(() => {
+    const map = new Map<string, Map<string, (typeof actions)[number][]>>();
 
-  // Group actions by company — include ALL companies from Business Management
-  const groupedActions = useMemo(() => {
-    const groups: Record<
-      string,
-      {
-        company: { id: string; canonicalName: string; isKey: boolean };
-        actions: WeeklyActionWithRelations[];
-      }
-    > = {};
-
-    // First, add all companies from Business Management
-    for (const company of companies) {
-      groups[company.id] = {
-        company,
-        actions: [],
-      };
+    for (const c of companies) {
+      map.set(c.id, new Map());
     }
 
-    // Then, assign actions to their companies
     for (const action of actions) {
-      const companyId = action.companyId;
-      if (!groups[companyId]) {
-        groups[companyId] = {
-          company: action.company ?? {
-            id: companyId,
-            canonicalName: "Unknown",
-            isKey: false,
-          },
-          actions: [],
-        };
+      // Apply status filter if set
+      if (statusFilter && action.status !== statusFilter) continue;
+
+      if (!map.has(action.companyId)) {
+        map.set(action.companyId, new Map());
       }
-      groups[companyId].actions.push(action);
+      const cycleMap = map.get(action.companyId)!;
+      if (!cycleMap.has(action.cycleId)) {
+        cycleMap.set(action.cycleId, []);
+      }
+      cycleMap.get(action.cycleId)!.push(action);
     }
 
-    return Object.values(groups).sort((a, b) => {
-      if (a.company.isKey !== b.company.isKey) return a.company.isKey ? -1 : 1;
-      return a.company.canonicalName.localeCompare(b.company.canonicalName);
-    });
-  }, [actions, companies]);
+    const rows = companies
+      .filter((c) => !c.isArchived)
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+      .map((c) => ({
+        company: c,
+        hasAnyAction: actions.some((a) => a.companyId === c.id),
+      }));
 
-  const activeCycle = cycles.find((c) => c.id === activeCycleId) ?? currentCycle;
-  const weekLabel = activeCycle
-    ? formatWeekLabel(activeCycle.year, activeCycle.weekNumber)
-    : "";
+    return { companyRows: rows, actionMap: map };
+  }, [companies, actions, statusFilter]);
+
+  // Navigation
+  const goToPrevMonth = () => {
+    if (viewMonth === 1) { setViewYear(viewYear - 1); setViewMonth(12); }
+    else setViewMonth(viewMonth - 1);
+  };
+  const goToNextMonth = () => {
+    if (viewMonth === 12) { setViewYear(viewYear + 1); setViewMonth(1); }
+    else setViewMonth(viewMonth + 1);
+  };
 
   // Find previous cycle for carryover
   const prevCycle = useMemo(() => {
-    if (!activeCycle) return null;
-    return cycles.find(
+    if (!currentCycle) return null;
+    return allCycles.find(
       (c) =>
-        (c.year === activeCycle.year && c.weekNumber === activeCycle.weekNumber - 1) ||
-        (activeCycle.weekNumber === 1 && c.year === activeCycle.year - 1 && c.weekNumber >= 52),
+        (c.year === currentCycle.year && c.weekNumber === currentCycle.weekNumber - 1) ||
+        (currentCycle.weekNumber === 1 && c.year === currentCycle.year - 1 && c.weekNumber >= 52),
     );
-  }, [cycles, activeCycle]);
+  }, [allCycles, currentCycle]);
+
+  const weekLabel = currentCycle
+    ? formatWeekLabel(currentCycle.year, currentCycle.weekNumber)
+    : "";
+
+  // Inline editing
+  const createAction = useCreateWeeklyAction();
+  const updateAction = useUpdateWeeklyAction();
+  const ensureCycle = useEnsureCycle();
+  const [editingCell, setEditingCell] = useState<EditingCell>(null);
+
+  const startEdit = useCallback(async (
+    companyId: string,
+    cycleId: string | null,
+    weekYear: number,
+    weekNumber: number,
+    action?: WeeklyAction,
+  ) => {
+    let resolvedCycleId = cycleId;
+    if (!resolvedCycleId) {
+      const result = await ensureCycle.mutateAsync({ year: weekYear, weekNumber });
+      resolvedCycleId = result.data.id;
+    }
+    setEditingCell({
+      companyId,
+      cycleId: resolvedCycleId,
+      weekYear,
+      weekNumber,
+      actionId: action?.id,
+      status: action?.status ?? "scheduled",
+    });
+  }, [ensureCycle]);
+
+  const saveEdit = useCallback((html: string) => {
+    if (!editingCell) return;
+
+    if (editingCell.actionId) {
+      if (html) {
+        const action = actions.find((a) => a.id === editingCell.actionId);
+        if (action && (html !== action.content || editingCell.status !== action.status)) {
+          updateAction.mutate({
+            id: editingCell.actionId,
+            lockVersion: action.lockVersion,
+            content: html,
+            status: editingCell.status,
+          });
+        }
+      }
+    } else {
+      if (html && editingCell.cycleId) {
+        createAction.mutate({
+          cycleId: editingCell.cycleId,
+          companyId: editingCell.companyId,
+          content: html,
+          status: editingCell.status,
+        });
+      }
+    }
+    setEditingCell(null);
+  }, [editingCell, actions, createAction, updateAction]);
+
+  const handleActionStatusChange = useCallback((actionId: string, lockVersion: number, newStatus: string) => {
+    updateAction.mutate({
+      id: actionId,
+      lockVersion,
+      status: newStatus,
+    });
+  }, [updateAction]);
 
   return (
     <div className="flex h-[calc(100vh-3.5rem)] flex-col">
       {/* Toolbar */}
-      <div className="flex flex-wrap items-center gap-3 border-b border-[var(--border)] px-4 py-3">
+      <div className="flex flex-wrap items-center gap-3 border-b border-[var(--border)] px-4 py-3 shrink-0">
         <h1 className="text-lg font-bold">주간회의</h1>
 
-        {/* Week selector */}
-        <select
-          value={activeCycleId ?? ""}
-          onChange={(e) => setSelectedCycleId(e.target.value || null)}
-          className="h-8 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 text-sm outline-none focus:ring-2 focus:ring-[var(--ring)]"
-        >
-          {currentCycle && (
-            <option value={currentCycle.id}>
-              {formatWeekLabel(currentCycle.year, currentCycle.weekNumber)} (현재)
-            </option>
-          )}
-          {cycles
-            .filter((c) => c.id !== currentCycle?.id)
-            .map((c) => (
-              <option key={c.id} value={c.id}>
-                {formatWeekLabel(c.year, c.weekNumber)}
-              </option>
-            ))}
-        </select>
+        <MonthPicker
+          year={viewYear}
+          month={viewMonth}
+          onPrev={goToPrevMonth}
+          onNext={goToNextMonth}
+          onChange={(y, m) => { setViewYear(y); setViewMonth(m); }}
+        />
 
         {/* Status filter */}
         <select
@@ -155,75 +533,75 @@ export default function WeeklyMeetingPage() {
       {/* Meeting Mode */}
       {meetingModeActive && (
         <MeetingModeView
-          actions={actions}
+          actions={currentActions}
           weekLabel={weekLabel}
         />
       )}
 
-      {/* Normal Action list */}
-      <div className={`flex-1 overflow-y-auto p-4 ${meetingModeActive ? "hidden" : ""}`}>
-        {actionsLoading && (
-          <p className="text-sm text-[var(--muted-foreground)]">로딩 중...</p>
-        )}
-
-        {!actionsLoading && groupedActions.length === 0 && (
-          <div className="flex flex-col items-center justify-center p-16 text-center">
-            <p className="text-lg font-medium">이번 주 액션이 없습니다</p>
-            <p className="mt-1 text-sm text-[var(--muted-foreground)]">
-              첫 번째 주간 액션을 생성하거나 지난 주에서 이월하세요.
-            </p>
-            <div className="mt-4 flex gap-2">
-              <button
-                onClick={() => setShowNewAction(true)}
-                className="rounded-md bg-[var(--primary)] px-4 py-2 text-sm text-[var(--primary-foreground)] hover:opacity-90"
-              >
-                + 새 액션
-              </button>
-              {prevCycle && (
-                <button
-                  onClick={() => setShowCarryover(true)}
-                  className="rounded-md border border-[var(--border)] px-4 py-2 text-sm hover:bg-[var(--muted)]"
-                >
-                  ↻ 이월
-                </button>
-              )}
-            </div>
+      {/* Table view */}
+      <div className={`flex-1 overflow-auto ${meetingModeActive ? "hidden" : ""}`}>
+        {isLoading && (
+          <div className="flex items-center justify-center p-8">
+            <p className="text-sm text-[var(--muted-foreground)]">로딩 중...</p>
           </div>
         )}
 
-        {groupedActions.map(({ company, actions: companyActions }) => (
-          <div key={company.id} className="mb-6">
-            <div className="flex items-center gap-2 mb-2">
-              {company.isKey && (
-                <span className="text-yellow-500 text-sm">★</span>
-              )}
-              <h2 className="text-sm font-bold">{company.canonicalName}</h2>
-              <span className="text-xs text-[var(--muted-foreground)]">
-                {companyActions.length}개 액션
+        <div className="min-w-full">
+          {/* Header */}
+          <div className="sticky top-0 z-10 flex border-b border-[var(--border)] bg-[var(--background)]">
+            <div className="sticky left-0 z-20 w-[220px] shrink-0 border-r border-[var(--border)] bg-[var(--background)] px-3 py-2">
+              <span className="text-sm font-bold text-[var(--muted-foreground)]">
+                고객사
               </span>
             </div>
-
-            <div className="space-y-2 pl-4">
-              {companyActions.length === 0 && (
-                <p className="text-xs text-[var(--muted-foreground)] py-2">
-                  이번 주 액션이 없습니다.{" "}
-                  <button
-                    onClick={() => setShowNewAction(true)}
-                    className="text-[var(--primary)] hover:underline"
+            {monthCycles.map((w) => {
+              const wKey = `${w.year}-${w.weekNumber}`;
+              const collapsed = collapsedWeeks.has(wKey);
+              return (
+                <div
+                  key={wKey}
+                  onClick={() => toggleWeek(wKey)}
+                  className={`shrink-0 border-r border-[var(--border)] cursor-pointer select-none transition-all ${
+                    collapsed
+                      ? "w-[40px] px-1 py-2 bg-[var(--muted)] opacity-40 hover:opacity-70"
+                      : "w-[320px] px-3 py-2 hover:bg-[var(--muted)]"
+                  }`}
+                  title={collapsed ? `${viewMonth}월 ${w.weekInMonth}주 표시` : `${viewMonth}월 ${w.weekInMonth}주 숨기기`}
+                >
+                  <span
+                    className="text-sm font-bold text-[var(--muted-foreground)]"
+                    style={collapsed ? { writingMode: "vertical-rl", textOrientation: "mixed" } : undefined}
                   >
-                    추가하기
-                  </button>
-                </p>
-              )}
-              {companyActions.map((action) => (
-                <ActionCard
-                  key={action.id}
-                  action={action}
-                />
-              ))}
-            </div>
+                    {viewMonth}월 {w.weekInMonth}주
+                  </span>
+                </div>
+              );
+            })}
           </div>
-        ))}
+
+          {/* Company rows */}
+          {companyRows.map(({ company }) => {
+            const cycleMap = actionMap.get(company.id);
+
+            return (
+              <WeeklyCompanyRow
+                key={company.id}
+                company={company}
+                monthCycles={monthCycles}
+                cycleMap={cycleMap}
+                editingCell={editingCell}
+                collapsedWeeks={collapsedWeeks}
+                onStartEdit={startEdit}
+                onSaveEdit={saveEdit}
+                onCancelEdit={() => setEditingCell(null)}
+                onStatusChange={(status) =>
+                  setEditingCell((prev) => prev ? { ...prev, status } : null)
+                }
+                onActionStatusChange={handleActionStatusChange}
+              />
+            );
+          })}
+        </div>
       </div>
 
       {/* Dialogs */}
@@ -236,14 +614,14 @@ export default function WeeklyMeetingPage() {
         />
       )}
 
-      {prevCycle && activeCycleId && activeCycle && (
+      {prevCycle && activeCycleId && currentCycle && (
         <CarryoverDialog
           open={showCarryover}
           onClose={() => setShowCarryover(false)}
           sourceCycleId={prevCycle.id}
           targetCycleId={activeCycleId}
           sourceLabel={formatWeekLabel(prevCycle.year, prevCycle.weekNumber)}
-          targetLabel={formatWeekLabel(activeCycle.year, activeCycle.weekNumber)}
+          targetLabel={formatWeekLabel(currentCycle.year, currentCycle.weekNumber)}
         />
       )}
 
@@ -251,7 +629,6 @@ export default function WeeklyMeetingPage() {
         open={showExcelDownload}
         onClose={() => setShowExcelDownload(false)}
         defaultType="weekly"
-        cycleId={activeCycleId ?? undefined}
       />
     </div>
   );

--- a/src/components/business-table/business-row.tsx
+++ b/src/components/business-table/business-row.tsx
@@ -8,6 +8,7 @@ import type { Stage, ProgressItem } from "@/types";
 interface BusinessRowProps {
   business: {
     id: string;
+    companyId?: string;
     name: string;
     embargoName?: string | null;
     visibility: string;
@@ -113,6 +114,7 @@ export function BusinessRow({ business, onClick, visibleStages, highlighted }: B
           item={selectedBlock}
           open={!!selectedBlock}
           onClose={() => setSelectedBlock(null)}
+          companyId={business.companyId}
         />
       )}
     </>

--- a/src/components/editor/inline-editor.tsx
+++ b/src/components/editor/inline-editor.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { TextStyle } from "@tiptap/extension-text-style";
+import { Color } from "@tiptap/extension-color";
+import { Highlight } from "@tiptap/extension-highlight";
+import { Placeholder } from "@tiptap/extension-placeholder";
+
+const TEXT_COLORS = [
+  { label: "기본", value: "" },
+  { label: "빨강", value: "#ef4444" },
+  { label: "파랑", value: "#3b82f6" },
+  { label: "초록", value: "#22c55e" },
+  { label: "주황", value: "#f97316" },
+  { label: "보라", value: "#a855f7" },
+];
+
+const HIGHLIGHT_COLORS = [
+  { label: "없음", value: "" },
+  { label: "노랑", value: "#fef08a" },
+  { label: "초록", value: "#bbf7d0" },
+  { label: "파랑", value: "#bfdbfe" },
+  { label: "분홍", value: "#fecdd3" },
+];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function MiniToolbar({ editor }: { editor: any }) {
+  const [showColors, setShowColors] = useState(false);
+  const [showHighlights, setShowHighlights] = useState(false);
+
+  if (!editor) return null;
+
+  const btn = (active: boolean) =>
+    `w-6 h-6 flex items-center justify-center rounded text-[10px] transition-colors ${
+      active ? "bg-[var(--primary)] text-[var(--primary-foreground)]" : "hover:bg-[var(--muted)]"
+    }`;
+
+  const currentColor = editor.getAttributes("textStyle").color ?? "";
+
+  return (
+    <div className="flex items-center gap-0.5 pb-1 mb-1 border-b border-[var(--border)]">
+      <button type="button" onClick={() => editor.chain().focus().toggleBold().run()} className={btn(editor.isActive("bold"))} title="볼드">
+        <strong>B</strong>
+      </button>
+      <button type="button" onClick={() => editor.chain().focus().toggleItalic().run()} className={btn(editor.isActive("italic"))} title="이탤릭">
+        <em>I</em>
+      </button>
+      <button type="button" onClick={() => editor.chain().focus().toggleStrike().run()} className={btn(editor.isActive("strike"))} title="취소선">
+        <s>S</s>
+      </button>
+
+      <span className="w-px h-4 bg-[var(--border)] mx-0.5" />
+
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => { setShowColors(!showColors); setShowHighlights(false); }}
+          className={`${btn(!!currentColor)} relative`}
+          title="글자 색"
+        >
+          <span className="font-bold">A</span>
+          <span className="absolute bottom-0 left-0.5 right-0.5 h-[2px] rounded-full" style={{ backgroundColor: currentColor || "var(--foreground)" }} />
+        </button>
+        {showColors && (
+          <div className="absolute top-full left-0 mt-1 z-50 flex gap-1 rounded-lg border border-[var(--border)] bg-[var(--background)] p-1.5 shadow-lg">
+            {TEXT_COLORS.map((c) => (
+              <button
+                key={c.value}
+                type="button"
+                onClick={() => { c.value ? editor.chain().focus().setColor(c.value).run() : editor.chain().focus().unsetColor().run(); setShowColors(false); }}
+                className={`w-5 h-5 rounded-full border-2 hover:scale-110 ${currentColor === c.value ? "border-[var(--primary)]" : "border-transparent"}`}
+                style={{ backgroundColor: c.value || "var(--foreground)" }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => { setShowHighlights(!showHighlights); setShowColors(false); }}
+          className={btn(editor.isActive("highlight"))}
+          title="형광펜"
+        >
+          H
+        </button>
+        {showHighlights && (
+          <div className="absolute top-full left-0 mt-1 z-50 flex gap-1 rounded-lg border border-[var(--border)] bg-[var(--background)] p-1.5 shadow-lg">
+            {HIGHLIGHT_COLORS.map((c) => (
+              <button
+                key={c.value}
+                type="button"
+                onClick={() => { c.value ? editor.chain().focus().toggleHighlight({ color: c.value }).run() : editor.chain().focus().unsetHighlight().run(); setShowHighlights(false); }}
+                className={`w-5 h-5 rounded-full border-2 hover:scale-110 ${editor.isActive("highlight", { color: c.value }) ? "border-[var(--primary)]" : "border-transparent"}`}
+                style={{ backgroundColor: c.value || "var(--muted)" }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <span className="w-px h-4 bg-[var(--border)] mx-0.5" />
+
+      <button type="button" onClick={() => editor.chain().focus().toggleBulletList().run()} className={btn(editor.isActive("bulletList"))} title="목록">
+        •
+      </button>
+    </div>
+  );
+}
+
+interface InlineEditorProps {
+  content: string;
+  placeholder?: string;
+  onSave: (html: string) => void;
+  onCancel: () => void;
+  /** Optional status for new actions */
+  status?: string;
+  onStatusChange?: (status: string) => void;
+}
+
+export function InlineEditor({ content, placeholder, onSave, onCancel, status, onStatusChange }: InlineEditorProps) {
+  const initialContentRef = useRef(content);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit,
+      TextStyle,
+      Color,
+      Highlight.configure({ multicolor: true }),
+      Placeholder.configure({ placeholder: placeholder ?? "내용 입력..." }),
+    ],
+    content: content || "",
+    editorProps: {
+      attributes: {
+        class: "outline-none min-h-[30px] text-xs",
+      },
+    },
+  });
+
+  useEffect(() => {
+    if (editor) {
+      editor.commands.setContent(content || "");
+      initialContentRef.current = content;
+      editor.commands.focus();
+    }
+  }, [editor, content]);
+
+  const handleSave = useCallback(() => {
+    if (!editor) return;
+    const html = editor.getHTML();
+    const clean = html === "<p></p>" ? "" : html;
+    // Dirty check: only save if content actually changed
+    if (clean !== initialContentRef.current) {
+      onSave(clean);
+    } else {
+      onCancel();
+    }
+  }, [editor, onSave, onCancel]);
+
+  const STATUS_OPTIONS = [
+    { value: "scheduled", label: "예정", color: "bg-gray-400" },
+    { value: "in_progress", label: "진행중", color: "bg-blue-500" },
+    { value: "completed", label: "완료", color: "bg-green-500" },
+    { value: "on_hold", label: "보류", color: "bg-yellow-500" },
+  ];
+
+  return (
+    <div
+      ref={containerRef}
+      className="rounded border border-[var(--primary)] bg-[var(--background)] px-2 py-1 overflow-hidden"
+      onClick={(e) => e.stopPropagation()}
+      onBlur={(e) => {
+        // Only save if focus leaves the entire editor container
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+          handleSave();
+        }
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onCancel();
+      }}
+    >
+      <MiniToolbar editor={editor} />
+      <EditorContent editor={editor} />
+      {/* Status selector row */}
+      {onStatusChange && (
+        <div className="flex items-center gap-1 pt-1 mt-1 border-t border-[var(--border)]">
+          <span className="text-[10px] text-[var(--muted-foreground)]">상태:</span>
+          {STATUS_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => onStatusChange(opt.value)}
+              className={`text-[10px] px-1.5 py-0.5 rounded-full transition-colors ${
+                status === opt.value
+                  ? `${opt.color} text-white`
+                  : "bg-[var(--muted)] text-[var(--muted-foreground)] hover:opacity-80"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/progress-blocks/block-detail.tsx
+++ b/src/components/progress-blocks/block-detail.tsx
@@ -7,13 +7,17 @@ import { TextStyle } from "@tiptap/extension-text-style";
 import { Color } from "@tiptap/extension-color";
 import { Highlight } from "@tiptap/extension-highlight";
 import { Placeholder } from "@tiptap/extension-placeholder";
+import DOMPurify from "dompurify";
 import { useUpdateProgressItem } from "@/hooks/use-progress-items";
-import type { ProgressItem } from "@/types";
+import { useWeeklyActions, useCurrentCycle, useWeeklyCycles } from "@/hooks/use-weekly-actions";
+import { getISOWeekNumber, getISOWeekYear } from "@/lib/weekly-cycle";
+import type { ProgressItem, WeeklyAction } from "@/types";
 
 interface BlockDetailProps {
   item: ProgressItem;
   open: boolean;
   onClose: () => void;
+  companyId?: string;
 }
 
 function MiniCalendar({ onDateClick }: { onDateClick: (day: number, month: number, year: number) => void }) {
@@ -219,10 +223,10 @@ function EditorToolbar({ editor }: { editor: any }) {
 
 const MIN_WIDTH = 540;
 const MIN_HEIGHT = 400;
-const DEFAULT_WIDTH = 860;
-const DEFAULT_HEIGHT = 620;
+const DEFAULT_WIDTH = 1080;
+const DEFAULT_HEIGHT = 780;
 
-export function BlockDetail({ item, open, onClose }: BlockDetailProps) {
+export function BlockDetail({ item, open, onClose, companyId }: BlockDetailProps) {
   const [title, setTitle] = useState(item.title ?? "");
   const [date, setDate] = useState(item.date ?? "");
   const [saving, setSaving] = useState(false);
@@ -324,6 +328,40 @@ export function BlockDetail({ item, open, onClose }: BlockDetailProps) {
     editor?.commands.setContent(item.content || "");
   }, [item.id, item.content, editor]);
 
+  // Weekly actions for right panel
+  const weeklyNow = new Date();
+  const currentWeekNum = getISOWeekNumber(weeklyNow);
+  const currentWeekYear = getISOWeekYear(weeklyNow);
+  const { data: currentCycleData } = useCurrentCycle();
+  const { data: allCyclesData } = useWeeklyCycles(currentWeekYear);
+  const weeklyCycle = currentCycleData?.data;
+  const weeklyCycles = allCyclesData?.data ?? [];
+  const prevWeeklyCycle = weeklyCycles.find(
+    (c) => (c.year === currentWeekYear && c.weekNumber === currentWeekNum - 1) ||
+           (currentWeekNum === 1 && c.year === currentWeekYear - 1 && c.weekNumber >= 52),
+  );
+  const nextWeeklyCycle = weeklyCycles.find(
+    (c) => (c.year === currentWeekYear && c.weekNumber === currentWeekNum + 1) ||
+           (currentWeekNum >= 52 && c.year === currentWeekYear + 1 && c.weekNumber === 1),
+  );
+
+  const { data: prevWeekActions } = useWeeklyActions(
+    prevWeeklyCycle ? { cycleId: prevWeeklyCycle.id } : undefined,
+  );
+  const { data: thisWeekActions } = useWeeklyActions(
+    weeklyCycle ? { cycleId: weeklyCycle.id } : undefined,
+  );
+  const { data: nextWeekActions } = useWeeklyActions(
+    nextWeeklyCycle ? { cycleId: nextWeeklyCycle.id } : undefined,
+  );
+
+  const filterByCompany = (data: WeeklyAction[]) =>
+    companyId ? data.filter((a) => a.companyId === companyId) : [];
+
+  const prevWeekItems = filterByCompany((prevWeekActions?.data ?? []) as WeeklyAction[]);
+  const thisWeekItems = filterByCompany((thisWeekActions?.data ?? []) as WeeklyAction[]);
+  const nextWeekItems = filterByCompany((nextWeekActions?.data ?? []) as WeeklyAction[]);
+
   if (!open) return null;
 
   const inputClass =
@@ -388,9 +426,41 @@ export function BlockDetail({ item, open, onClose }: BlockDetailProps) {
           </p>
         </div>
 
-        {/* Right: calendar */}
-        <div className="shrink-0 border-l border-[var(--border)] pl-5">
-          <MiniCalendar onDateClick={handleCalendarDateClick} />
+        {/* Right: calendar + weekly actions */}
+        <div className="w-[300px] shrink-0 border-l border-[var(--border)] pl-5 flex flex-col overflow-y-auto">
+          <div className="shrink-0 flex justify-center">
+            <MiniCalendar onDateClick={handleCalendarDateClick} />
+          </div>
+
+          {/* Weekly actions */}
+          {companyId && (
+            <div className="mt-4 pt-4 border-t border-[var(--border)] flex flex-col gap-4 flex-1 min-h-0">
+              {[
+                { label: "지난 주", items: prevWeekItems },
+                { label: "이번 주", items: thisWeekItems },
+                { label: "다음 주", items: nextWeekItems },
+              ].map(({ label, items }) => (
+                <div key={label}>
+                  <h4 className="text-xs font-bold text-[var(--muted-foreground)] mb-1.5">
+                    {label}
+                  </h4>
+                  {items.length === 0 ? (
+                    <p className="text-[10px] text-[var(--muted-foreground)]">내용 없음</p>
+                  ) : (
+                    <div className="flex flex-col gap-1">
+                      {items.map((a) => (
+                        <div
+                          key={a.id}
+                          className="rounded bg-[var(--muted)] px-2 py-1.5 text-xs break-words [&_p]:m-0 [&_ul]:pl-3 [&_ul]:list-disc [&_ol]:pl-3 [&_ol]:list-decimal"
+                          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(a.content) }}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
 
         {/* Resize handle */}

--- a/src/hooks/use-weekly-actions.ts
+++ b/src/hooks/use-weekly-actions.ts
@@ -108,6 +108,37 @@ export function useArchiveWeeklyAction() {
   });
 }
 
+// Ensure a cycle exists (create if needed via POST), returns cycle
+export function useEnsureCycle() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { year: number; weekNumber: number }) =>
+      fetchJson<{ data: WeeklyCycle }>("/api/weekly-cycles", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["weeklyCycles"] });
+    },
+  });
+}
+
+// Fetch actions for multiple cycles in a SINGLE request (batch API)
+export function useWeeklyActionsMultiCycle(cycleIds: string[]) {
+  const ids = cycleIds.join(",");
+  return useQuery<ApiListResponse<WeeklyAction>>({
+    queryKey: ["weeklyActions", "multi", cycleIds],
+    queryFn: () => {
+      if (cycleIds.length === 0) return Promise.resolve({ data: [], total: 0 });
+      return fetchJson<ApiListResponse<WeeklyAction>>(
+        `/api/weekly-actions?cycle_ids=${encodeURIComponent(ids)}`,
+      );
+    },
+    enabled: cycleIds.length > 0,
+  });
+}
+
 // Carryover
 export function useCarryoverCandidates(sourceCycleId: string | null) {
   return useQuery<{ data: WeeklyAction[] }>({

--- a/src/lib/weekly-cycle.ts
+++ b/src/lib/weekly-cycle.ts
@@ -55,3 +55,33 @@ export function getWeekDateRange(
 export function formatWeekLabel(year: number, weekNumber: number): string {
   return `${year}-W${String(weekNumber).padStart(2, "0")}`;
 }
+
+/**
+ * Get weeks for a given month. Only counts weeks where Monday falls in the month.
+ * Returns array of { year, weekNumber, weekInMonth } sorted chronologically.
+ * weekInMonth is 1-based (1주, 2주, ...).
+ */
+export function getWeeksInMonth(
+  year: number,
+  month: number, // 1-12
+): { year: number; weekNumber: number; weekInMonth: number }[] {
+  const weeks: { year: number; weekNumber: number; weekInMonth: number }[] = [];
+  const daysInMonth = new Date(year, month, 0).getDate();
+  let weekIndex = 0;
+
+  for (let day = 1; day <= daysInMonth; day++) {
+    const date = new Date(year, month - 1, day);
+    if (date.getDay() === 1) { // Monday only
+      const wy = getISOWeekYear(date);
+      const wn = getISOWeekNumber(date);
+      weekIndex++;
+      weeks.push({ year: wy, weekNumber: wn, weekInMonth: weekIndex });
+    }
+  }
+
+  return weeks;
+}
+
+export function formatMonthLabel(year: number, month: number): string {
+  return `${year}년 ${month}월`;
+}


### PR DESCRIPTION
## Summary
- Redesign weekly page as a company x week table (Excel-like layout) with monthly navigation and month picker (with outside-click-to-close)
- Inline Tiptap rich text editor per cell with dirty check on blur (only saves if content changed), status selector for new/existing actions, and colored status badges with click-to-cycle
- Batch API: `cycle_ids` parameter on `/api/weekly-actions` for single-request multi-cycle fetch (fixes N+1 problem), POST handler on `/api/weekly-cycles` for auto-creating cycles
- **PRESERVED** all existing features from master: MeetingModeToggle, MeetingModeView, CarryoverDialog, NewActionDialog, WeekEndActions, QuickActionsBar, StatusFilter
- Block detail modal: added weekly actions panel (prev/this/next week) in right side below calendar, with `companyId` prop passed from BusinessRow
- No import scripts (prisma/import-weekly.ts, prisma/check-empty.ts) included — those are data scripts, not features

## Review fixes from PR #145
- **Restored deleted features**: Meeting Mode, Carryover, Status Filter, New Action, WeekEnd actions all preserved in toolbar
- **Status/priority management**: Inline editor has status selector; existing actions show colored status badge with click-to-cycle
- **N+1 API fix**: `cycle_ids=id1,id2,id3` batch parameter replaces N parallel requests with ONE
- **MonthPicker outside click**: useRef + useEffect with mousedown listener closes picker on outside click
- **Removed import scripts**: No prisma/import-weekly.ts or prisma/check-empty.ts in this PR

Closes #143

## Test plan
- [ ] Navigate to /weekly — verify table view renders with company rows and week columns
- [ ] Click month picker, click outside — verify it closes
- [ ] Click empty cell — verify inline editor appears with status selector
- [ ] Type content and blur — verify action is created
- [ ] Click existing action — verify inline editor opens with current content
- [ ] Blur without changes — verify no API call (dirty check)
- [ ] Click status badge on existing action — verify status cycles
- [ ] Toggle Meeting Mode — verify MeetingModeView appears
- [ ] Click week column header — verify collapse/expand
- [ ] Open block detail from business management — verify weekly actions panel shows prev/this/next week
- [ ] Check Network tab — verify single request for multi-cycle fetch (cycle_ids parameter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)