### PR TITLE
fix: critical bugs - auth, lockVersion, error swallowing, KST, header

### DIFF
--- a/src/app/api/bulk/assign/route.ts
+++ b/src/app/api/bulk/assign/route.ts
@@ -1,12 +1,16 @@
-// TODO: Add authentication/authorization middleware.
-// Currently unauthenticated — acceptable for internal tooling, but must be
-// secured before any external or multi-tenant exposure.
-
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { createAuditLog } from "@/lib/audit";
+import { auth } from "@/lib/auth";
 
 export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: "UNAUTHORIZED", message: "Authentication required" },
+      { status: 401 },
+    );
+  }
   const body = await request.json();
   const { entityType, entityIds, assignedTo } = body;
 

--- a/src/app/api/businesses/[id]/progress-items/route.ts
+++ b/src/app/api/businesses/[id]/progress-items/route.ts
@@ -63,7 +63,7 @@ export async function POST(request: NextRequest, context: Params) {
       stage,
       title: trimmedTitle,
       content: trimmedContent,
-      date: date || new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10),
+      date: date || new Intl.DateTimeFormat("sv-SE", { timeZone: "Asia/Seoul" }).format(new Date()),
       sortOrder: sortOrder ?? (maxSort._max.sortOrder ?? 0) + 1,
     },
   });

--- a/src/app/api/businesses/[id]/route.ts
+++ b/src/app/api/businesses/[id]/route.ts
@@ -78,8 +78,7 @@ export async function PUT(request: NextRequest, context: Params) {
       }
     }
 
-    const isFunnelOnly = Object.keys(updateData).length === 1 && updateData.funnelNumbers !== undefined;
-    const data: Record<string, unknown> = isFunnelOnly ? {} : { lockVersion: { increment: 1 } };
+    const data: Record<string, unknown> = { lockVersion: { increment: 1 } };
     if (updateData.funnelNumbers !== undefined) data.funnelNumbers = updateData.funnelNumbers;
     if (updateData.name !== undefined) data.name = updateData.name.trim();
     if (updateData.embargoName !== undefined) data.embargoName = updateData.embargoName;

--- a/src/app/api/progress-items/[id]/route.ts
+++ b/src/app/api/progress-items/[id]/route.ts
@@ -47,7 +47,7 @@ export async function PUT(request: NextRequest, context: Params) {
       entityType: "progressItem",
       entityId: id,
       snapshot: JSON.parse(JSON.stringify(updated)),
-    }).catch((err) => console.error("Version snapshot failed:", err));
+    });
 
     await createAuditLog({
       entityType: "progress_item",
@@ -57,7 +57,7 @@ export async function PUT(request: NextRequest, context: Params) {
         before: JSON.parse(JSON.stringify(current)),
         after: JSON.parse(JSON.stringify(updated)),
       },
-    }).catch((err) => console.error("Audit log failed:", err));
+    });
 
     return NextResponse.json({ data: updated });
   } catch (e) {
@@ -101,7 +101,7 @@ export async function POST(request: NextRequest, context: Params) {
         entityType: "progressItem",
         entityId: id,
         snapshot: JSON.parse(JSON.stringify(updated)),
-      }).catch((err) => console.error("Version snapshot failed:", err));
+      });
 
       await createAuditLog({
         entityType: "progress_item",
@@ -109,7 +109,7 @@ export async function POST(request: NextRequest, context: Params) {
         action: "move",
         changes: { fromStage, toStage: targetStage },
         summary: `Moved from ${fromStage} to ${targetStage}`,
-      }).catch((err) => console.error("Audit log failed:", err));
+      });
 
       return NextResponse.json({ data: updated });
     }
@@ -136,7 +136,7 @@ export async function DELETE(_request: NextRequest, context: Params) {
       entityId: id,
       action: "delete",
       changes: JSON.parse(JSON.stringify(item)),
-    }).catch((err) => console.error("Audit log failed:", err));
+    });
 
     return new NextResponse(null, { status: 204 });
   } catch (e) {

--- a/src/components/layout/top-nav.tsx
+++ b/src/components/layout/top-nav.tsx
@@ -48,8 +48,8 @@ export function TopNav() {
     return () => document.removeEventListener("keydown", handleGlobalKeyDown);
   }, [handleGlobalKeyDown]);
 
-  // Hide nav on login/pending pages or when not authenticated
-  if (HIDDEN_PATHS.includes(pathname) || !session) return null;
+  // Hide nav only on login/pending pages
+  if (HIDDEN_PATHS.includes(pathname)) return null;
 
   return (
     <>
@@ -91,7 +91,9 @@ export function TopNav() {
               {mounted ? (theme === "dark" ? "☀" : "☽") : "◑"}
             </button>
 
-            {session?.user ? (
+            {sessionStatus === "loading" ? (
+              <div className="h-8 w-20 animate-pulse rounded-md bg-[var(--muted)]" />
+            ) : session?.user ? (
               <button
                 onClick={() => signOut({ callbackUrl: "/login" })}
                 className="h-8 rounded-md border border-[var(--border)] px-2 text-xs hover:bg-[var(--muted)] transition-colors flex items-center gap-1.5"


### PR DESCRIPTION
## Summary
- **#156** TopNav 헤더가 세션 로딩 중 사라지는 버그 수정 — `!session` 조건 제거, 로딩 스켈레톤 추가
- **#157** `/api/bulk/assign` 인증 체크 누락 — `auth()` 세션 검증 추가
- **#158** Business funnelNumbers만 업데이트 시 `lockVersion` 미증가 — 항상 increment
- **#159** progress-items API에서 audit/version 에러 `.catch()`로 삼키던 것 제거 — 에러 정상 전파
- **#160** progress-items 날짜 생성 시 `+9h` 하드코딩 → `Intl.DateTimeFormat("sv-SE", { timeZone: "Asia/Seoul" })` 명시적 타임존 사용

## Test plan
- [ ] 로그인 전/세션 로딩 중 헤더가 정상 표시되는지 확인
- [ ] 미인증 상태에서 `/api/bulk/assign` POST 시 401 응답 확인
- [ ] Business funnelNumbers 수정 후 lockVersion 증가 확인
- [ ] progress-item 수정/이동/삭제 시 audit log 정상 기록 확인
- [ ] progress-item 생성 시 date가 KST 기준 정확한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)