### PR TITLE
fix: 테마 전환 버튼 첫 클릭 미반응 수정

### DIFF
--- a/src/components/layout/top-nav.tsx
+++ b/src/components/layout/top-nav.tsx
@@ -30,7 +30,7 @@ export function TopNav() {
   const [searchOpen, setSearchOpen] = useState(false);
   const { data: session, status: sessionStatus } = useSession();
   const pathname = usePathname();
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   const userRole = session?.user?.role;
 
@@ -84,11 +84,11 @@ export function TopNav() {
             </button>
 
             <button
-              onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+              onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
               className="h-8 w-8 rounded-md border border-[var(--border)] text-sm hover:bg-[var(--accent)] transition-colors"
               aria-label="테마 전환"
             >
-              {mounted ? (theme === "dark" ? "☀" : "☽") : "◑"}
+              {mounted ? (resolvedTheme === "dark" ? "☀" : "☽") : "◑"}
             </button>
 
             {sessionStatus === "loading" ? (


### PR DESCRIPTION
## Summary
- `useTheme()`의 `theme` → `resolvedTheme`으로 변경
- 초기값 `"system"`이 아닌 실제 적용 테마(`"dark"`/`"light"`) 기준으로 토글

## Test plan
- [ ] 페이지 첫 로드 후 테마 버튼 첫 클릭에 테마 전환 확인
- [ ] 연속 클릭 시 다크↔라이트 정상 전환 확인

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)