### PR TITLE
feat: 감사 로그에 클라이언트 IP 기록

### DIFF
--- a/prisma/migrations/20260417010000_add_ip_to_audit_log/migration.sql
+++ b/prisma/migrations/20260417010000_add_ip_to_audit_log/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "audit_logs" ADD COLUMN "ip" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -341,6 +341,7 @@ model AuditLog {
   entityId   String   @map("entity_id")
   action     String
   actorId    String?  @map("actor_id")
+  ip         String?
   changes    Json?
   summary    String?
   createdAt  DateTime @default(now()) @map("created_at")

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/auth";
-import { createAuditLog } from "@/lib/audit";
+import { createAuditLog, getClientIp } from "@/lib/audit";
 import { VALID_ROLES, VALID_STATUSES, isValidRole, isValidStatus } from "@/lib/constants";
 
 export async function GET(request: NextRequest) {
@@ -76,6 +76,7 @@ export async function PUT(request: NextRequest) {
       entityType: "user",
       entityId: id,
       action: "role_change",
+      ip: getClientIp(request),
       changes: { before: { role: current.role }, after: { role } },
     });
   }
@@ -85,6 +86,7 @@ export async function PUT(request: NextRequest) {
       entityType: "user",
       entityId: id,
       action: "status_change",
+      ip: getClientIp(request),
       changes: { before: { status: current.status }, after: { status } },
     });
   }

--- a/src/app/api/audit-logs/route.ts
+++ b/src/app/api/audit-logs/route.ts
@@ -45,6 +45,7 @@ export async function GET(request: NextRequest) {
       orderBy: { createdAt: "desc" },
       take: limit,
       skip: offset,
+      omit: { ip: true },
     }),
     prisma.auditLog.count({ where }),
   ]);

--- a/src/app/api/bulk/assign/route.ts
+++ b/src/app/api/bulk/assign/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { createAuditLog } from "@/lib/audit";
+import { createAuditLog, getClientIp } from "@/lib/audit";
 import { auth } from "@/lib/auth";
 
 export async function POST(request: NextRequest) {
@@ -41,6 +41,7 @@ export async function POST(request: NextRequest) {
         entityId: record.id,
         action: "update",
         changes: { assignedTo },
+        ip: getClientIp(request),
         summary: `Bulk assignee change`,
       });
     }
@@ -62,6 +63,7 @@ export async function POST(request: NextRequest) {
         entityId: record.id,
         action: "update",
         changes: { assignedTo },
+        ip: getClientIp(request),
         summary: `Bulk assignee change`,
       });
     }

--- a/src/app/api/businesses/[id]/progress-items/route.ts
+++ b/src/app/api/businesses/[id]/progress-items/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { createAuditLog } from "@/lib/audit";
+import { createAuditLog, getClientIp } from "@/lib/audit";
 import { createVersionSnapshot } from "@/lib/version";
 import { STAGES, isValidStage } from "@/lib/constants";
 
@@ -78,6 +78,7 @@ export async function POST(request: NextRequest, context: Params) {
     entityType: "progress_item",
     entityId: item.id,
     action: "create",
+    ip: getClientIp(request),
     changes: { businessId, stage, title: trimmedTitle, content: trimmedContent },
   });
 

--- a/src/app/api/businesses/[id]/route.ts
+++ b/src/app/api/businesses/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-import { createAuditLog } from "@/lib/audit";
+import { createAuditLog, getClientIp } from "@/lib/audit";
 import { createVersionSnapshot } from "@/lib/version";
 import { checkLockVersion, ConflictError, conflictResponse } from "@/lib/conflict";
 
@@ -109,6 +109,7 @@ export async function PUT(request: NextRequest, context: Params) {
       entityType: "business",
       entityId: id,
       action: "update",
+      ip: getClientIp(request),
       changes: {
         before: JSON.parse(JSON.stringify(current)),
         after: JSON.parse(JSON.stringify(updated)),
@@ -133,7 +134,7 @@ export async function POST(request: NextRequest, context: Params) {
         where: { id },
         data: { isArchived: true, archivedAt: new Date(), lockVersion: { increment: 1 } },
       });
-      await createAuditLog({ entityType: "business", entityId: id, action: "delete", summary: "Archived" });
+      await createAuditLog({ entityType: "business", entityId: id, action: "delete", ip: getClientIp(request), summary: "Archived" });
       return NextResponse.json({ data: business });
     }
 
@@ -142,7 +143,7 @@ export async function POST(request: NextRequest, context: Params) {
         where: { id },
         data: { isArchived: false, archivedAt: null, lockVersion: { increment: 1 } },
       });
-      await createAuditLog({ entityType: "business", entityId: id, action: "create", summary: "Restored" });
+      await createAuditLog({ entityType: "business", entityId: id, action: "create", ip: getClientIp(request), summary: "Restored" });
       return NextResponse.json({ data: business });
     }
 

--- a/src/app/api/businesses/route.ts
+++ b/src/app/api/businesses/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { createAuditLog } from "@/lib/audit";
+import { createAuditLog, getClientIp } from "@/lib/audit";
 import { createVersionSnapshot } from "@/lib/version";
 
 export async function GET(request: NextRequest) {
@@ -86,6 +86,7 @@ export async function POST(request: NextRequest) {
       entityType: "business",
       entityId: business.id,
       action: "create",
+      ip: getClientIp(request),
       changes: { name, companyId, visibility },
     });
 

--- a/src/app/api/companies/[id]/route.ts
+++ b/src/app/api/companies/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { createAuditLog } from "@/lib/audit";
+import { createAuditLog, getClientIp } from "@/lib/audit";
 import { checkLockVersion, ConflictError, conflictResponse } from "@/lib/conflict";
 
 type Params = { params: Promise<{ id: string }> };
@@ -92,6 +92,7 @@ export async function PUT(request: NextRequest, context: Params) {
       entityType: "company",
       entityId: id,
       action: "update",
+      ip: getClientIp(request),
       changes: {
         before,
         after: {
@@ -122,7 +123,7 @@ export async function POST(request: NextRequest, context: Params) {
         where: { id },
         data: { isArchived: true, archivedAt: new Date(), lockVersion: { increment: 1 } },
       });
-      await createAuditLog({ entityType: "company", entityId: id, action: "delete", summary: "Archived" });
+      await createAuditLog({ entityType: "company", entityId: id, action: "delete", ip: getClientIp(request), summary: "Archived" });
       return NextResponse.json({ data: company });
     }
 
@@ -131,7 +132,7 @@ export async function POST(request: NextRequest, context: Params) {
         where: { id },
         data: { isArchived: false, archivedAt: null, lockVersion: { increment: 1 } },
       });
-      await createAuditLog({ entityType: "company", entityId: id, action: "create", summary: "Restored" });
+      await createAuditLog({ entityType: "company", entityId: id, action: "create", ip: getClientIp(request), summary: "Restored" });
       return NextResponse.json({ data: company });
     }
 

--- a/src/app/api/companies/merge/route.ts
+++ b/src/app/api/companies/merge/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { createAuditLog } from "@/lib/audit";
+import { createAuditLog, getClientIp } from "@/lib/audit";
 import { requireAdmin } from "@/lib/auth";
 
 export async function POST(request: NextRequest) {
@@ -97,6 +97,7 @@ export async function POST(request: NextRequest) {
     entityType: "company",
     entityId: canonical_id,
     action: "merge",
+    ip: getClientIp(request),
     summary: `Merged ${mergeCompanies.map((c) => c.canonicalName).join(", ")} into ${canonical.canonicalName}`,
     changes: {
       merged_ids: merge_ids,

--- a/src/app/api/companies/reorder/route.ts
+++ b/src/app/api/companies/reorder/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { createAuditLog } from "@/lib/audit";
+import { createAuditLog, getClientIp } from "@/lib/audit";
 
 export async function PUT(request: NextRequest) {
   try {
@@ -47,6 +47,7 @@ export async function PUT(request: NextRequest) {
       entityType: "company",
       entityId: "batch",
       action: "move",
+      ip: getClientIp(request),
       summary: `Reordered ${orderedIds.length} companies`,
     });
 

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { createAuditLog } from "@/lib/audit";
+import { createAuditLog, getClientIp } from "@/lib/audit";
 
 const ALLOWED_SORT_FIELDS = ["canonicalName", "sortOrder", "createdAt"];
 
@@ -83,6 +83,7 @@ export async function POST(request: NextRequest) {
       entityType: "company",
       entityId: company.id,
       action: "create",
+      ip: getClientIp(request),
       changes: { canonicalName, aliases, isKey },
     });
 

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { createWorkbook, generateFilename, workbookToBuffer } from "@/lib/excel";
-import { createAuditLog } from "@/lib/audit";
+import { createAuditLog, getClientIp } from "@/lib/audit";
 import { getWeeksInMonth } from "@/lib/weekly-cycle";
 import type ExcelJS from "exceljs";
 
@@ -179,10 +179,12 @@ export async function POST(request: NextRequest) {
   }
   const { type, ...options } = body;
 
+  const ip = getClientIp(request);
+
   if (type === "monthly") {
-    return handleMonthlyExport(options as { year: number; month: number });
+    return handleMonthlyExport(options as { year: number; month: number }, ip);
   } else if (type === "yearly") {
-    return handleYearlyExport(options as { year: number });
+    return handleYearlyExport(options as { year: number }, ip);
   }
 
   return NextResponse.json(
@@ -338,7 +340,7 @@ function buildWeeklySheet(
 
 // ── 월간 Export ───────────────────────────────────────────────
 
-async function handleMonthlyExport(options: { year: number; month: number }) {
+async function handleMonthlyExport(options: { year: number; month: number }, ip: string | null) {
   const year = Number(options.year);
   const month = Number(options.month);
   if (!Number.isFinite(year) || !Number.isFinite(month) || month < 1 || month > 12) {
@@ -422,6 +424,7 @@ async function handleMonthlyExport(options: { year: number; month: number }) {
       entityType: "export",
       entityId: `${year}-${month}`,
       action: "download",
+      ip,
       changes: { type: "monthly", year, month, filename },
     });
   } catch (e) {
@@ -438,7 +441,7 @@ async function handleMonthlyExport(options: { year: number; month: number }) {
 
 // ── 연간 Export ───────────────────────────────────────────────
 
-async function handleYearlyExport(options: { year: number }) {
+async function handleYearlyExport(options: { year: number }, ip: string | null) {
   const year = Number(options.year);
   if (!Number.isFinite(year)) {
     return NextResponse.json(
@@ -529,6 +532,7 @@ async function handleYearlyExport(options: { year: number }) {
       entityType: "export",
       entityId: String(year),
       action: "download",
+      ip,
       changes: { type: "yearly", year, filename },
     });
   } catch (e) {

--- a/src/app/api/notes/route.ts
+++ b/src/app/api/notes/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { createAuditLog } from "@/lib/audit";
+import { createAuditLog, getClientIp } from "@/lib/audit";
 import { checkLockVersion, ConflictError, conflictResponse } from "@/lib/conflict";
 
 const VALID_TAGS = ["situation", "decision", "risk", "follow_up"] as const;
@@ -84,6 +84,7 @@ export async function POST(request: NextRequest) {
     entityType: "internal_note",
     entityId: note.id,
     action: "create",
+    ip: getClientIp(request),
     summary: title ?? "New note",
   });
 
@@ -160,6 +161,7 @@ export async function PUT(request: NextRequest) {
     entityType: "internal_note",
     entityId: id,
     action: "update",
+    ip: getClientIp(request),
     changes: {
       before: {
         title: current.title,

--- a/src/app/api/progress-items/[id]/route.ts
+++ b/src/app/api/progress-items/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { createAuditLog } from "@/lib/audit";
+import { createAuditLog, getClientIp } from "@/lib/audit";
 import { createVersionSnapshot } from "@/lib/version";
 
 import { STAGES, isValidStage } from "@/lib/constants";
@@ -53,6 +53,7 @@ export async function PUT(request: NextRequest, context: Params) {
       entityType: "progress_item",
       entityId: id,
       action: "update",
+      ip: getClientIp(request),
       changes: {
         before: JSON.parse(JSON.stringify(current)),
         after: JSON.parse(JSON.stringify(updated)),
@@ -124,6 +125,7 @@ export async function POST(request: NextRequest, context: Params) {
         entityType: "progress_item",
         entityId: id,
         action: "move",
+        ip: getClientIp(request),
         changes: { fromStage, toStage: targetStage },
         summary: `Moved from ${fromStage} to ${targetStage}`,
       });
@@ -138,7 +140,7 @@ export async function POST(request: NextRequest, context: Params) {
   }
 }
 
-export async function DELETE(_request: NextRequest, context: Params) {
+export async function DELETE(request: NextRequest, context: Params) {
   const { id } = await context.params;
   try {
     const item = await prisma.progressItem.findUnique({ where: { id } });
@@ -155,6 +157,7 @@ export async function DELETE(_request: NextRequest, context: Params) {
       entityType: "progress_item",
       entityId: id,
       action: "delete",
+      ip: getClientIp(request),
       changes: JSON.parse(JSON.stringify(item)),
     });
 

--- a/src/app/api/weekly-actions/[id]/route.ts
+++ b/src/app/api/weekly-actions/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { createAuditLog } from "@/lib/audit";
+import { createAuditLog, getClientIp } from "@/lib/audit";
 import { createVersionSnapshot } from "@/lib/version";
 import { checkLockVersion, ConflictError, conflictResponse } from "@/lib/conflict";
 
@@ -74,6 +74,7 @@ export async function PUT(request: NextRequest, context: Params) {
     entityType: "weekly_action",
     entityId: id,
     action,
+    ip: getClientIp(request),
     changes: {
       before: JSON.parse(JSON.stringify(current)),
       after: JSON.parse(JSON.stringify(updated)),
@@ -97,7 +98,7 @@ export async function POST(request: NextRequest, context: Params) {
       where: { id },
       data: { isArchived: true, archivedAt: new Date(), lockVersion: { increment: 1 } },
     });
-    await createAuditLog({ entityType: "weekly_action", entityId: id, action: "delete", summary: "Archived" });
+    await createAuditLog({ entityType: "weekly_action", entityId: id, action: "delete", ip: getClientIp(request), summary: "Archived" });
     return NextResponse.json({ data: a });
   }
 
@@ -106,7 +107,7 @@ export async function POST(request: NextRequest, context: Params) {
       where: { id },
       data: { isArchived: false, archivedAt: null, lockVersion: { increment: 1 } },
     });
-    await createAuditLog({ entityType: "weekly_action", entityId: id, action: "create", summary: "Restored" });
+    await createAuditLog({ entityType: "weekly_action", entityId: id, action: "create", ip: getClientIp(request), summary: "Restored" });
     return NextResponse.json({ data: a });
   }
 

--- a/src/app/api/weekly-actions/carryover/route.ts
+++ b/src/app/api/weekly-actions/carryover/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { createAuditLog } from "@/lib/audit";
+import { createAuditLog, getClientIp } from "@/lib/audit";
 import { createVersionSnapshot } from "@/lib/version";
 
 export async function GET(request: NextRequest) {
@@ -87,6 +87,7 @@ export async function POST(request: NextRequest) {
         entityType: "weekly_action",
         entityId: newAction.id,
         action: "carryover",
+        ip: getClientIp(request),
         changes: {
           sourceCycleId,
           targetCycleId,

--- a/src/app/api/weekly-actions/route.ts
+++ b/src/app/api/weekly-actions/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { createAuditLog } from "@/lib/audit";
+import { createAuditLog, getClientIp } from "@/lib/audit";
 import { createVersionSnapshot } from "@/lib/version";
 
 export async function GET(request: NextRequest) {
@@ -97,6 +97,7 @@ export async function POST(request: NextRequest) {
     entityType: "weekly_action",
     entityId: action.id,
     action: "create",
+    ip: getClientIp(request),
     changes: { content: content.trim(), companyId, status, priority },
   });
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -2,13 +2,27 @@ export default function PrivacyPage() {
   return (
     <div className="max-w-2xl mx-auto p-8">
       <h1 className="text-2xl font-bold mb-4">개인정보처리방침</h1>
-      <p className="text-sm text-[var(--muted-foreground)] mb-4">최종 수정일: 2026-04-06</p>
+      <p className="text-sm text-[var(--muted-foreground)] mb-4">최종 수정일: 2026-05-04</p>
       <div className="space-y-4 text-sm">
         <p>Meeting Minutes(이하 &quot;서비스&quot;)는 내부 운영 도구로, Google OAuth를 통해 인증된 사용자만 접근할 수 있습니다.</p>
         <h2 className="font-semibold text-lg">수집하는 정보</h2>
-        <p>Google 계정의 이름, 이메일 주소, 프로필 사진을 수집합니다. 이 정보는 사용자 식별 및 서비스 내 표시 목적으로만 사용됩니다.</p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>Google 계정의 이름, 이메일 주소, 프로필 사진 — 사용자 식별 및 서비스 내 표시</li>
+          <li>감사 로그(audit log)에 기록되는 클라이언트 IP — 보안 사고 추적 및 변경 이력 검증</li>
+          <li>로그인 실패 IP 및 시각 — 무차별 대입 공격 방어</li>
+        </ul>
         <h2 className="font-semibold text-lg">정보의 이용</h2>
-        <p>수집된 정보는 서비스 운영 및 사용자 인증 목적으로만 사용되며, 제3자에게 제공되지 않습니다.</p>
+        <p>수집된 정보는 서비스 운영, 사용자 인증, 보안 감사 목적으로만 사용되며, 제3자에게 제공되지 않습니다.</p>
+        <h2 className="font-semibold text-lg">보존 기간</h2>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>감사 로그 및 IP 기록: 최대 1년 (정기 정리 대상)</li>
+          <li>로그인 실패 기록: 7일 (자동 만료)</li>
+          <li>Google 계정 정보: 계정 삭제 시까지</li>
+        </ul>
+        <p className="text-xs text-[var(--muted-foreground)]">
+          IP 주소는 GDPR 등 일부 법제에서 개인식별정보로 분류될 수 있어 본 항목에 명시합니다.
+          API 응답에는 노출되지 않으며, 데이터베이스에서 직접 조회 권한을 가진 운영자만 확인할 수 있습니다.
+        </p>
         <h2 className="font-semibold text-lg">문의</h2>
         <p>개인정보 관련 문의: gkfkd747@gmail.com</p>
       </div>

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,12 +1,14 @@
 import { NextRequest } from "next/server";
 import { prisma } from "./prisma";
 
+// x-forwarded-for is trusted only behind a reverse proxy (e.g. Vercel).
+// Truncate to 45 chars (max IPv6 length) to prevent oversized header injection.
 export function getClientIp(request: NextRequest): string | null {
-  return (
+  const ip =
     request.headers.get("x-forwarded-for")?.split(",")[0].trim() ||
     request.headers.get("x-real-ip") ||
-    null
-  );
+    null;
+  return ip ? ip.slice(0, 45) : null;
 }
 
 interface CreateAuditLogParams {

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,10 +1,20 @@
+import { NextRequest } from "next/server";
 import { prisma } from "./prisma";
+
+export function getClientIp(request: NextRequest): string | null {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0].trim() ||
+    request.headers.get("x-real-ip") ||
+    null
+  );
+}
 
 interface CreateAuditLogParams {
   entityType: string;
   entityId: string;
   action: string;
   actorId?: string | null;
+  ip?: string | null;
   changes?: Record<string, unknown> | null;
   summary?: string | null;
 }
@@ -14,6 +24,7 @@ export async function createAuditLog({
   entityId,
   action,
   actorId = null,
+  ip = null,
   changes = null,
   summary = null,
 }: CreateAuditLogParams) {
@@ -23,6 +34,7 @@ export async function createAuditLog({
       entityId,
       action,
       actorId,
+      ip,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       changes: (changes ?? undefined) as any,
       summary,

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,7 +1,11 @@
+import "server-only";
 import { NextRequest } from "next/server";
 import { prisma } from "./prisma";
 
 // x-forwarded-for is trusted only behind a reverse proxy (e.g. Vercel).
+// In local dev (no proxy) this returns null; in production behind Vercel it
+// returns the actual client IP (the platform sets x-forwarded-for itself, so
+// values cannot be spoofed by clients).
 // Truncate to 45 chars (max IPv6 length) to prevent oversized header injection.
 export function getClientIp(request: NextRequest): string | null {
   const ip =


### PR DESCRIPTION
## Summary
- `AuditLog` 테이블에 `ip` nullable 컬럼 추가
- `getClientIp(request)` 헬퍼 함수로 `x-forwarded-for` / `x-real-ip` 헤더에서 IP 추출
- 15개 API route 파일의 22개 `createAuditLog` 호출에 IP 전달
- 감사로그 API 응답에서 `ip` 필드를 `omit`하여 **DB 직접 조회로만 확인 가능**

closes #192

## Test plan
- [ ] 배포 후 DB에서 `SELECT ip FROM audit_logs ORDER BY created_at DESC LIMIT 5` 로 IP 기록 확인
- [ ] `/api/audit-logs` 응답에 `ip` 필드가 포함되지 않는지 확인
- [ ] Prisma migration 적용 확인 (`prisma migrate deploy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)