### PR TITLE
feat: 주간 체크포인트 + 완전 롤백 복원 + 타임라인 UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ NEXTAUTH_URL="http://localhost:3000"
 
 # Password login (optional, for shared access)
 APP_PASSWORD="your-shared-password"
+
+# Cron secret (Vercel Cron Jobs Bearer token for /api/cron/*)
+CRON_SECRET="generate-with-openssl-rand-base64-32"

--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ APP_PASSWORD="your-shared-password"
 
 # Cron secret (Vercel Cron Jobs Bearer token for /api/cron/*)
 CRON_SECRET="generate-with-openssl-rand-base64-32"
+
+# Extra password gate for entering admin mode (/admin/*)
+ADMIN_UNLOCK_PASSWORD="your-admin-unlock-password"

--- a/prisma/migrations/20260421010000_add_weekly_checkpoint/migration.sql
+++ b/prisma/migrations/20260421010000_add_weekly_checkpoint/migration.sql
@@ -1,0 +1,19 @@
+-- Create weekly_checkpoints table
+CREATE TABLE IF NOT EXISTS "weekly_checkpoints" (
+  "id" TEXT NOT NULL,
+  "kind" TEXT NOT NULL,
+  "label" TEXT,
+  "year" INTEGER,
+  "week_number" INTEGER,
+  "payload" JSONB NOT NULL,
+  "byte_size" INTEGER,
+  "taken_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expires_at" TIMESTAMPTZ,
+  "created_by" TEXT,
+  CONSTRAINT "weekly_checkpoints_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "weekly_checkpoints_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS "weekly_checkpoints_taken_at_idx" ON "weekly_checkpoints"("taken_at" DESC);
+CREATE INDEX IF NOT EXISTS "weekly_checkpoints_kind_taken_at_idx" ON "weekly_checkpoints"("kind", "taken_at" DESC);
+CREATE INDEX IF NOT EXISTS "weekly_checkpoints_expires_at_idx" ON "weekly_checkpoints"("expires_at");

--- a/prisma/migrations/20260421020000_add_audit_log_snapshot_ref/migration.sql
+++ b/prisma/migrations/20260421020000_add_audit_log_snapshot_ref/migration.sql
@@ -1,0 +1,13 @@
+-- Link orphaned AuditLogs to their pre_restore snapshot so that
+-- entityId references deleted by restore can still be resolved.
+ALTER TABLE "audit_logs"
+  ADD COLUMN IF NOT EXISTS "snapshot_checkpoint_id" TEXT;
+
+ALTER TABLE "audit_logs"
+  ADD CONSTRAINT "audit_logs_snapshot_checkpoint_id_fkey"
+  FOREIGN KEY ("snapshot_checkpoint_id")
+  REFERENCES "weekly_checkpoints"("id")
+  ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS "audit_logs_snapshot_checkpoint_id_idx"
+  ON "audit_logs"("snapshot_checkpoint_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -337,20 +337,23 @@ model InternalNote {
 // ============================================================
 
 model AuditLog {
-  id         String   @id @default(uuid())
-  entityType String   @map("entity_type")
-  entityId   String   @map("entity_id")
-  action     String
-  actorId    String?  @map("actor_id")
-  changes    Json?
-  summary    String?
-  createdAt  DateTime @default(now()) @map("created_at")
+  id                    String   @id @default(uuid())
+  entityType            String   @map("entity_type")
+  entityId              String   @map("entity_id")
+  action                String
+  actorId               String?  @map("actor_id")
+  changes               Json?
+  summary               String?
+  snapshotCheckpointId  String?  @map("snapshot_checkpoint_id")
+  createdAt             DateTime @default(now()) @map("created_at")
 
-  actor User? @relation(fields: [actorId], references: [id])
+  actor              User?             @relation(fields: [actorId], references: [id])
+  snapshotCheckpoint WeeklyCheckpoint? @relation("AuditLogSnapshot", fields: [snapshotCheckpointId], references: [id], onDelete: SetNull)
 
   @@index([entityType, entityId])
   @@index([createdAt(sort: Desc)])
   @@index([actorId])
+  @@index([snapshotCheckpointId])
   @@map("audit_logs")
 }
 
@@ -457,7 +460,8 @@ model WeeklyCheckpoint {
   expiresAt   DateTime? @map("expires_at")
   createdById String?   @map("created_by")
 
-  createdBy User? @relation("CheckpointCreatedBy", fields: [createdById], references: [id])
+  createdBy          User?      @relation("CheckpointCreatedBy", fields: [createdById], references: [id])
+  orphanedAuditLogs  AuditLog[] @relation("AuditLogSnapshot")
 
   @@index([takenAt(sort: Desc)])
   @@index([kind, takenAt(sort: Desc)])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,6 +94,7 @@ model User {
   actionVersions       WeeklyActionVersion[]
   noteVersions         InternalNoteVersion[]
   recentViews          RecentView[]
+  checkpointsCreated   WeeklyCheckpoint[]    @relation("CheckpointCreatedBy")
 
   @@map("users")
 }
@@ -438,4 +439,28 @@ model RecentView {
   @@index([userId, viewedAt(sort: Desc)])
   @@index([sessionId, viewedAt(sort: Desc)])
   @@map("recent_views")
+}
+
+// ============================================================
+// Weekly Checkpoint (full-snapshot restore)
+// ============================================================
+
+model WeeklyCheckpoint {
+  id          String    @id @default(uuid())
+  kind        String    // 'weekly' | 'pre_restore'
+  label       String?
+  year        Int?
+  weekNumber  Int?      @map("week_number")
+  payload     Json      @db.JsonB
+  byteSize    Int?      @map("byte_size")
+  takenAt     DateTime  @default(now()) @map("taken_at")
+  expiresAt   DateTime? @map("expires_at")
+  createdById String?   @map("created_by")
+
+  createdBy User? @relation("CheckpointCreatedBy", fields: [createdById], references: [id])
+
+  @@index([takenAt(sort: Desc)])
+  @@index([kind, takenAt(sort: Desc)])
+  @@index([expiresAt])
+  @@map("weekly_checkpoints")
 }

--- a/src/app/admin-unlock/page.tsx
+++ b/src/app/admin-unlock/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { fetchJson } from "@/lib/fetch";
+
+function UnlockForm() {
+  const router = useRouter();
+  const search = useSearchParams();
+  const next = search.get("next") ?? "/admin/users";
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      await fetchJson("/api/admin/unlock", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+      });
+      router.replace(next);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "잘못된 비밀번호");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      className="mx-auto mt-20 max-w-sm space-y-3 rounded-md border border-[var(--border)] bg-[var(--card)] p-6"
+    >
+      <h1 className="text-lg font-bold">관리자 모드</h1>
+      <p className="text-xs text-[var(--muted-foreground)]">
+        관리자 기능에 접근하려면 비밀번호를 입력하세요.
+      </p>
+      <input
+        type="password"
+        autoFocus
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="비밀번호"
+        className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm"
+      />
+      {error && <p className="text-xs text-red-600">{error}</p>}
+      <button
+        type="submit"
+        disabled={loading || !password}
+        className="w-full rounded-md bg-[var(--primary)] px-4 py-2 text-sm text-[var(--primary-foreground)] disabled:opacity-50"
+      >
+        {loading ? "확인 중..." : "들어가기"}
+      </button>
+    </form>
+  );
+}
+
+export default function AdminUnlockPage() {
+  return (
+    <Suspense>
+      <UnlockForm />
+    </Suspense>
+  );
+}

--- a/src/app/admin-unlock/page.tsx
+++ b/src/app/admin-unlock/page.tsx
@@ -48,7 +48,7 @@ function UnlockForm() {
         placeholder="비밀번호"
         className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm"
       />
-      {error && <p className="text-xs text-red-600">{error}</p>}
+      {error && <p className="text-xs text-[var(--destructive)]">{error}</p>}
       <button
         type="submit"
         disabled={loading || !password}

--- a/src/app/admin/checkpoints/page.tsx
+++ b/src/app/admin/checkpoints/page.tsx
@@ -1,0 +1,413 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { fetchJson } from "@/lib/fetch";
+
+type TimelineEntry =
+  | {
+      type: "checkpoint";
+      at: string;
+      id: string;
+      kind: "weekly" | "pre_restore";
+      label: string | null;
+      year: number | null;
+      weekNumber: number | null;
+      byteSize: number | null;
+      expiresAt: string | null;
+      createdById: string | null;
+      auditCountSincePrev: number;
+    }
+  | {
+      type: "restore";
+      at: string;
+      id: string;
+      restoredCheckpointId: string;
+      restoredCheckpointLabel: string | null;
+      actorId: string | null;
+    };
+
+interface TableDiff {
+  willDelete: number;
+  willInsert: number;
+  willUpdate: number;
+}
+
+interface CheckpointDiffResponse {
+  data: {
+    checkpointId: string;
+    takenAt: string;
+    diff: Record<string, TableDiff>;
+  };
+}
+
+const TABLE_LABELS: Record<string, string> = {
+  companies: "기업",
+  companyAliases: "기업 별칭",
+  businesses: "사업",
+  progressItems: "진행 항목",
+  weeklyCycles: "주간 사이클",
+  weeklyActions: "주간 액션",
+  internalNotes: "내부 메모",
+};
+
+function formatBytes(n: number | null): string {
+  if (n == null) return "-";
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function formatDate(s: string | null): string {
+  if (!s) return "-";
+  return new Date(s).toLocaleString("ko-KR");
+}
+
+export default function CheckpointsPage() {
+  const [entries, setEntries] = useState<TimelineEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [label, setLabel] = useState("");
+  const [diffFor, setDiffFor] = useState<string | null>(null);
+  const [diff, setDiff] = useState<Record<string, TableDiff> | null>(null);
+  const [restoreFor, setRestoreFor] = useState<
+    Extract<TimelineEntry, { type: "checkpoint" }> | null
+  >(null);
+  const [confirmText, setConfirmText] = useState("");
+  const [password, setPassword] = useState("");
+  const [restoring, setRestoring] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await fetchJson<{ data: TimelineEntry[] }>(
+        "/api/admin/checkpoints/timeline",
+      );
+      setEntries(res.data);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const createCheckpoint = async () => {
+    setCreating(true);
+    setMessage(null);
+    try {
+      await fetchJson("/api/admin/checkpoints", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label: label.trim() || null }),
+      });
+      setLabel("");
+      setMessage("스냅샷이 생성되었습니다.");
+      await load();
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : "생성 실패");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const loadDiff = async (id: string) => {
+    setDiffFor(id);
+    setDiff(null);
+    try {
+      const res = await fetchJson<CheckpointDiffResponse>(
+        `/api/admin/checkpoints/${id}/diff`,
+      );
+      setDiff(res.data.diff);
+    } catch {
+      setDiff(null);
+    }
+  };
+
+  const doRestore = async () => {
+    if (!restoreFor) return;
+    setRestoring(true);
+    setMessage(null);
+    try {
+      await fetchJson(`/api/admin/checkpoints/${restoreFor.id}/restore`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirmText, password }),
+      });
+      setMessage(
+        "복원 완료. 복원 직전 상태는 pre_restore 체크포인트로 7일간 보관됩니다.",
+      );
+      setRestoreFor(null);
+      setConfirmText("");
+      setPassword("");
+      await load();
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : "복원 실패");
+    } finally {
+      setRestoring(false);
+    }
+  };
+
+  // A restore event (desc order) means the entries AFTER it in the array
+  // (= older) are part of an "abandoned branch" visually.
+  let passedRestore = false;
+
+  return (
+    <div>
+      <h1 className="mb-4 text-lg font-bold">체크포인트</h1>
+
+      <div className="mb-4 rounded-md border border-[var(--border)] bg-[var(--card)] p-4">
+        <h2 className="mb-2 text-sm font-semibold">새 스냅샷 생성</h2>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="라벨 (선택, 예: 2026-W17)"
+            className="flex-1 rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm"
+          />
+          <button
+            onClick={createCheckpoint}
+            disabled={creating}
+            className="rounded-md bg-[var(--primary)] px-4 py-2 text-sm text-[var(--primary-foreground)] disabled:opacity-50"
+          >
+            {creating ? "생성 중..." : "스냅샷 생성"}
+          </button>
+        </div>
+      </div>
+
+      {message && (
+        <div className="mb-4 rounded-md border border-[var(--border)] bg-[var(--muted)] px-3 py-2 text-sm">
+          {message}
+        </div>
+      )}
+
+      {loading && (
+        <p className="text-sm text-[var(--muted-foreground)]">로딩 중...</p>
+      )}
+
+      <div className="relative pl-6">
+        <div className="absolute left-2 top-0 bottom-0 w-px bg-[var(--border)]" />
+        {entries.map((e) => {
+          if (e.type === "restore") {
+            const marker = (
+              <div key={e.id} className="relative py-3">
+                <div className="absolute -left-[18px] top-4 flex h-4 w-4 items-center justify-center rounded-full border-2 border-amber-500 bg-amber-100 text-[10px] text-amber-700">
+                  ⟲
+                </div>
+                <div className="text-sm text-amber-700">
+                  복원됨 →{" "}
+                  <strong>
+                    {e.restoredCheckpointLabel ?? e.restoredCheckpointId.slice(0, 8)}
+                  </strong>{" "}
+                  <span className="text-xs text-[var(--muted-foreground)]">
+                    ({formatDate(e.at)})
+                  </span>
+                </div>
+                <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+                  이 아래(더 과거) 항목들은 이전 가지입니다.
+                </p>
+              </div>
+            );
+            passedRestore = true;
+            return marker;
+          }
+
+          const isPreRestore = e.kind === "pre_restore";
+          const dimmed = passedRestore;
+
+          return (
+            <div
+              key={e.id}
+              className={`relative py-3 ${dimmed ? "opacity-60" : ""}`}
+            >
+              <div
+                className={`absolute -left-[18px] top-4 h-4 w-4 rounded-full border-2 ${
+                  isPreRestore
+                    ? "border-amber-500 bg-amber-200"
+                    : "border-blue-500 bg-blue-200"
+                }`}
+              />
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                        isPreRestore
+                          ? "bg-amber-100 text-amber-800"
+                          : "bg-blue-100 text-blue-800"
+                      }`}
+                    >
+                      {e.kind}
+                    </span>
+                    <span className="text-sm font-medium">
+                      {e.label ?? e.id.slice(0, 8)}
+                    </span>
+                    <span className="text-xs text-[var(--muted-foreground)]">
+                      {formatDate(e.at)}
+                    </span>
+                  </div>
+                  <div className="mt-1 flex flex-wrap gap-x-3 text-xs text-[var(--muted-foreground)]">
+                    <span>크기 {formatBytes(e.byteSize)}</span>
+                    {e.expiresAt && (
+                      <span>만료 {formatDate(e.expiresAt)}</span>
+                    )}
+                    <span>
+                      이 이후 변경{" "}
+                      <strong className="text-[var(--foreground)]">
+                        {e.auditCountSincePrev}
+                      </strong>
+                      건
+                    </span>
+                  </div>
+                </div>
+                <div className="flex shrink-0 gap-1">
+                  <button
+                    onClick={() => loadDiff(e.id)}
+                    className="rounded-md border border-[var(--border)] px-2 py-1 text-xs hover:bg-[var(--muted)]"
+                  >
+                    diff
+                  </button>
+                  <button
+                    onClick={() => setRestoreFor(e)}
+                    className="rounded-md bg-red-600 px-2 py-1 text-xs text-white hover:bg-red-700"
+                  >
+                    복원
+                  </button>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+        {!loading && entries.length === 0 && (
+          <p className="py-4 text-sm text-[var(--muted-foreground)]">
+            체크포인트가 없습니다.
+          </p>
+        )}
+      </div>
+
+      {diffFor && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          onClick={() => {
+            setDiffFor(null);
+            setDiff(null);
+          }}
+        >
+          <div
+            className="max-h-[80vh] w-[90vw] max-w-xl overflow-auto rounded-md border border-[var(--border)] bg-[var(--card)] p-4"
+            onClick={(ev) => ev.stopPropagation()}
+          >
+            <h3 className="mb-3 text-base font-bold">복원 시 변화 (diff)</h3>
+            {!diff && (
+              <p className="text-sm text-[var(--muted-foreground)]">
+                계산 중...
+              </p>
+            )}
+            {diff && (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-[var(--border)] text-left text-xs uppercase text-[var(--muted-foreground)]">
+                    <th className="py-2">테이블</th>
+                    <th className="py-2 text-right">추가</th>
+                    <th className="py-2 text-right">변경</th>
+                    <th className="py-2 text-right">삭제</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {Object.entries(diff).map(([table, d]) => (
+                    <tr key={table} className="border-b border-[var(--border)]">
+                      <td className="py-2">{TABLE_LABELS[table] ?? table}</td>
+                      <td className="py-2 text-right text-green-600">
+                        +{d.willInsert}
+                      </td>
+                      <td className="py-2 text-right text-amber-600">
+                        ~{d.willUpdate}
+                      </td>
+                      <td className="py-2 text-right text-red-600">
+                        -{d.willDelete}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+            <div className="mt-4 flex justify-end">
+              <button
+                onClick={() => {
+                  setDiffFor(null);
+                  setDiff(null);
+                }}
+                className="rounded-md border border-[var(--border)] px-3 py-1.5 text-sm hover:bg-[var(--muted)]"
+              >
+                닫기
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {restoreFor && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          onClick={() => setRestoreFor(null)}
+        >
+          <div
+            className="w-[90vw] max-w-md rounded-md border border-[var(--border)] bg-[var(--card)] p-4"
+            onClick={(ev) => ev.stopPropagation()}
+          >
+            <h3 className="mb-2 text-base font-bold text-red-600">
+              체크포인트로 복원
+            </h3>
+            <p className="mb-3 text-sm">
+              <strong>{restoreFor.label ?? restoreFor.id}</strong> (
+              {formatDate(restoreFor.at)})
+            </p>
+            <p className="mb-3 text-xs text-red-600">
+              대상 테이블이 모두 TRUNCATE 후 스냅샷 기준으로 재구성됩니다. 이
+              시점 이후의 모든 변경은 사라집니다. 복원 직전 상태는 자동으로
+              pre_restore 스냅샷에 7일간 보관됩니다.
+            </p>
+
+            <label className="mb-2 block text-xs text-[var(--muted-foreground)]">
+              확인을 위해 <code>RESTORE</code>를 입력하세요.
+            </label>
+            <input
+              type="text"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              className="mb-3 w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm"
+            />
+
+            <label className="mb-2 block text-xs text-[var(--muted-foreground)]">
+              공유 비밀번호
+            </label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mb-4 w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm"
+            />
+
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setRestoreFor(null)}
+                className="rounded-md border border-[var(--border)] px-3 py-1.5 text-sm hover:bg-[var(--muted)]"
+              >
+                취소
+              </button>
+              <button
+                onClick={doRestore}
+                disabled={restoring || confirmText !== "RESTORE" || !password}
+                className="rounded-md bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {restoring ? "복원 중..." : "복원 실행"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 const navItems = [
   { href: "/admin/users", label: "사용자" },
   { href: "/admin/logs", label: "감사 로그" },
+  { href: "/admin/checkpoints", label: "체크포인트" },
   { href: "/admin/settings", label: "설정" },
 ];
 

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 const navItems = [
   { href: "/admin/users", label: "사용자" },
@@ -16,10 +17,23 @@ export default function AdminLayout({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
+  const router = useRouter();
+  const [locking, setLocking] = useState(false);
+
+  const lockAdmin = async () => {
+    setLocking(true);
+    try {
+      await fetch("/api/admin/unlock", { method: "DELETE" });
+      router.replace("/");
+      router.refresh();
+    } finally {
+      setLocking(false);
+    }
+  };
 
   return (
     <div className="flex min-h-[calc(100vh-3.5rem)]">
-      <aside className="w-56 shrink-0 border-r border-[var(--border)] bg-[var(--card)] p-4">
+      <aside className="flex w-56 shrink-0 flex-col border-r border-[var(--border)] bg-[var(--card)] p-4">
         <h2 className="mb-4 text-sm font-bold uppercase tracking-wider text-[var(--muted-foreground)]">
           관리자
         </h2>
@@ -38,6 +52,13 @@ export default function AdminLayout({
             </Link>
           ))}
         </nav>
+        <button
+          onClick={lockAdmin}
+          disabled={locking}
+          className="mt-auto rounded-md border border-[var(--border)] px-3 py-2 text-xs text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-red-600 disabled:opacity-50"
+        >
+          {locking ? "종료 중..." : "관리자 모드 종료"}
+        </button>
       </aside>
       <div className="flex-1 p-6">{children}</div>
     </div>

--- a/src/app/api/admin/checkpoints/[id]/diff/route.ts
+++ b/src/app/api/admin/checkpoints/[id]/diff/route.ts
@@ -9,12 +9,24 @@ interface TableDiff {
   willUpdate: number;
 }
 
-type SnapRow = { id: string; lockVersion?: number };
+type SnapRow = {
+  id: string;
+  lockVersion?: number | null;
+  updatedAt?: Date | string | null;
+  createdAt?: Date | string | null;
+};
 
-function diffByIdAndVersion(
-  current: SnapRow[],
-  snapshot: SnapRow[],
-): TableDiff {
+function toIso(v: Date | string | null | undefined): string | null {
+  if (v == null) return null;
+  return v instanceof Date ? v.toISOString() : String(v);
+}
+
+/**
+ * Compare current and snapshot rows by id, then detect changes using
+ * lockVersion → updatedAt → createdAt in that priority order.
+ * Returns 0 for willUpdate only when neither side has any version signal.
+ */
+function diffRows(current: SnapRow[], snapshot: SnapRow[]): TableDiff {
   const snapMap = new Map(snapshot.map((r) => [r.id, r]));
   const curMap = new Map(current.map((r) => [r.id, r]));
 
@@ -26,28 +38,18 @@ function diffByIdAndVersion(
       willDelete++;
       continue;
     }
-    if (
-      cur.lockVersion !== undefined &&
-      snap.lockVersion !== undefined &&
-      cur.lockVersion !== snap.lockVersion
-    ) {
-      willUpdate++;
+    if (cur.lockVersion != null && snap.lockVersion != null) {
+      if (cur.lockVersion !== snap.lockVersion) willUpdate++;
+    } else if (cur.updatedAt != null && snap.updatedAt != null) {
+      if (toIso(cur.updatedAt) !== toIso(snap.updatedAt)) willUpdate++;
+    } else if (cur.createdAt != null && snap.createdAt != null) {
+      if (toIso(cur.createdAt) !== toIso(snap.createdAt)) willUpdate++;
     }
   }
   let willInsert = 0;
   for (const id of snapMap.keys()) if (!curMap.has(id)) willInsert++;
 
   return { willDelete, willInsert, willUpdate };
-}
-
-function diffById(current: SnapRow[], snapshot: SnapRow[]): TableDiff {
-  const snapIds = new Set(snapshot.map((r) => r.id));
-  const curIds = new Set(current.map((r) => r.id));
-  let willDelete = 0;
-  for (const id of curIds) if (!snapIds.has(id)) willDelete++;
-  let willInsert = 0;
-  for (const id of snapIds) if (!curIds.has(id)) willInsert++;
-  return { willDelete, willInsert, willUpdate: 0 };
 }
 
 export async function GET(
@@ -84,33 +86,41 @@ export async function GET(
     weeklyCycles,
     weeklyActions,
     internalNotes,
-  ] = await Promise.all([
-    prisma.company.findMany({ select: { id: true, lockVersion: true } }),
-    prisma.companyAlias.findMany({ select: { id: true } }),
-    prisma.business.findMany({ select: { id: true, lockVersion: true } }),
-    prisma.progressItem.findMany({ select: { id: true, lockVersion: true } }),
-    prisma.weeklyCycle.findMany({ select: { id: true } }),
-    prisma.weeklyAction.findMany({ select: { id: true, lockVersion: true } }),
-    prisma.internalNote.findMany({ select: { id: true, lockVersion: true } }),
+  ] = await prisma.$transaction([
+    prisma.company.findMany({
+      select: { id: true, lockVersion: true, updatedAt: true },
+    }),
+    prisma.companyAlias.findMany({
+      select: { id: true, createdAt: true },
+    }),
+    prisma.business.findMany({
+      select: { id: true, lockVersion: true, updatedAt: true },
+    }),
+    prisma.progressItem.findMany({
+      select: { id: true, lockVersion: true, updatedAt: true },
+    }),
+    prisma.weeklyCycle.findMany({
+      select: { id: true, createdAt: true },
+    }),
+    prisma.weeklyAction.findMany({
+      select: { id: true, lockVersion: true, updatedAt: true },
+    }),
+    prisma.internalNote.findMany({
+      select: { id: true, lockVersion: true, updatedAt: true },
+    }),
   ]);
 
   const diff = {
-    companies: diffByIdAndVersion(companies, payload.companies as SnapRow[]),
-    companyAliases: diffById(companyAliases, payload.companyAliases as SnapRow[]),
-    businesses: diffByIdAndVersion(businesses, payload.businesses as SnapRow[]),
-    progressItems: diffByIdAndVersion(
-      progressItems,
-      payload.progressItems as SnapRow[],
+    companies: diffRows(companies, payload.companies as SnapRow[]),
+    companyAliases: diffRows(
+      companyAliases,
+      payload.companyAliases as SnapRow[],
     ),
-    weeklyCycles: diffById(weeklyCycles, payload.weeklyCycles as SnapRow[]),
-    weeklyActions: diffByIdAndVersion(
-      weeklyActions,
-      payload.weeklyActions as SnapRow[],
-    ),
-    internalNotes: diffByIdAndVersion(
-      internalNotes,
-      payload.internalNotes as SnapRow[],
-    ),
+    businesses: diffRows(businesses, payload.businesses as SnapRow[]),
+    progressItems: diffRows(progressItems, payload.progressItems as SnapRow[]),
+    weeklyCycles: diffRows(weeklyCycles, payload.weeklyCycles as SnapRow[]),
+    weeklyActions: diffRows(weeklyActions, payload.weeklyActions as SnapRow[]),
+    internalNotes: diffRows(internalNotes, payload.internalNotes as SnapRow[]),
   };
 
   return NextResponse.json({

--- a/src/app/api/admin/checkpoints/[id]/diff/route.ts
+++ b/src/app/api/admin/checkpoints/[id]/diff/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/auth";
+import type { CheckpointPayload } from "@/lib/checkpoint";
+
+interface TableDiff {
+  willDelete: number;
+  willInsert: number;
+  willUpdate: number;
+}
+
+type SnapRow = { id: string; lockVersion?: number };
+
+function diffByIdAndVersion(
+  current: SnapRow[],
+  snapshot: SnapRow[],
+): TableDiff {
+  const snapMap = new Map(snapshot.map((r) => [r.id, r]));
+  const curMap = new Map(current.map((r) => [r.id, r]));
+
+  let willDelete = 0;
+  let willUpdate = 0;
+  for (const [id, cur] of curMap) {
+    const snap = snapMap.get(id);
+    if (!snap) {
+      willDelete++;
+      continue;
+    }
+    if (
+      cur.lockVersion !== undefined &&
+      snap.lockVersion !== undefined &&
+      cur.lockVersion !== snap.lockVersion
+    ) {
+      willUpdate++;
+    }
+  }
+  let willInsert = 0;
+  for (const id of snapMap.keys()) if (!curMap.has(id)) willInsert++;
+
+  return { willDelete, willInsert, willUpdate };
+}
+
+function diffById(current: SnapRow[], snapshot: SnapRow[]): TableDiff {
+  const snapIds = new Set(snapshot.map((r) => r.id));
+  const curIds = new Set(current.map((r) => r.id));
+  let willDelete = 0;
+  for (const id of curIds) if (!snapIds.has(id)) willDelete++;
+  let willInsert = 0;
+  for (const id of snapIds) if (!curIds.has(id)) willInsert++;
+  return { willDelete, willInsert, willUpdate: 0 };
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    await requireAdmin();
+  } catch {
+    return NextResponse.json(
+      { error: "FORBIDDEN", message: "Admin role required" },
+      { status: 403 },
+    );
+  }
+
+  const { id } = await params;
+  const checkpoint = await prisma.weeklyCheckpoint.findUnique({
+    where: { id },
+  });
+  if (!checkpoint) {
+    return NextResponse.json(
+      { error: "NOT_FOUND", message: "Checkpoint not found" },
+      { status: 404 },
+    );
+  }
+
+  const payload = checkpoint.payload as unknown as CheckpointPayload;
+
+  const [
+    companies,
+    companyAliases,
+    businesses,
+    progressItems,
+    weeklyCycles,
+    weeklyActions,
+    internalNotes,
+  ] = await Promise.all([
+    prisma.company.findMany({ select: { id: true, lockVersion: true } }),
+    prisma.companyAlias.findMany({ select: { id: true } }),
+    prisma.business.findMany({ select: { id: true, lockVersion: true } }),
+    prisma.progressItem.findMany({ select: { id: true, lockVersion: true } }),
+    prisma.weeklyCycle.findMany({ select: { id: true } }),
+    prisma.weeklyAction.findMany({ select: { id: true, lockVersion: true } }),
+    prisma.internalNote.findMany({ select: { id: true, lockVersion: true } }),
+  ]);
+
+  const diff = {
+    companies: diffByIdAndVersion(companies, payload.companies as SnapRow[]),
+    companyAliases: diffById(companyAliases, payload.companyAliases as SnapRow[]),
+    businesses: diffByIdAndVersion(businesses, payload.businesses as SnapRow[]),
+    progressItems: diffByIdAndVersion(
+      progressItems,
+      payload.progressItems as SnapRow[],
+    ),
+    weeklyCycles: diffById(weeklyCycles, payload.weeklyCycles as SnapRow[]),
+    weeklyActions: diffByIdAndVersion(
+      weeklyActions,
+      payload.weeklyActions as SnapRow[],
+    ),
+    internalNotes: diffByIdAndVersion(
+      internalNotes,
+      payload.internalNotes as SnapRow[],
+    ),
+  };
+
+  return NextResponse.json({
+    data: {
+      checkpointId: id,
+      takenAt: checkpoint.takenAt,
+      diff,
+    },
+  });
+}

--- a/src/app/api/admin/checkpoints/[id]/restore/route.ts
+++ b/src/app/api/admin/checkpoints/[id]/restore/route.ts
@@ -27,6 +27,55 @@ const USER_REF_FIELDS: Record<keyof CheckpointPayload, string[]> = {
   internalNotes: ["createdById", "updatedById"],
 };
 
+/** AuditLog.entityType → CheckpointPayload key */
+const AUDIT_ENTITY_TO_PAYLOAD_KEY: Record<string, keyof CheckpointPayload> = {
+  company: "companies",
+  business: "businesses",
+  progress_item: "progressItems",
+  weekly_action: "weeklyActions",
+  internal_note: "internalNotes",
+};
+
+function collectIds(
+  payload: CheckpointPayload,
+  key: keyof CheckpointPayload,
+): Set<string> {
+  const rows = payload[key] as Array<{ id?: unknown }>;
+  const out = new Set<string>();
+  for (const r of rows) if (typeof r?.id === "string") out.add(r.id);
+  return out;
+}
+
+/**
+ * Point AuditLogs of rows that disappear in the restore to the pre_restore
+ * snapshot so orphan entityIds remain resolvable until the snapshot expires.
+ */
+async function linkOrphanAuditLogs(
+  preRestoreId: string,
+  before: CheckpointPayload,
+  after: CheckpointPayload,
+): Promise<number> {
+  let updated = 0;
+  for (const [entityType, payloadKey] of Object.entries(
+    AUDIT_ENTITY_TO_PAYLOAD_KEY,
+  )) {
+    const beforeIds = collectIds(before, payloadKey);
+    const afterIds = collectIds(after, payloadKey);
+    const disappearing = [...beforeIds].filter((id) => !afterIds.has(id));
+    if (disappearing.length === 0) continue;
+    const result = await prisma.auditLog.updateMany({
+      where: {
+        entityType,
+        entityId: { in: disappearing },
+        snapshotCheckpointId: null,
+      },
+      data: { snapshotCheckpointId: preRestoreId },
+    });
+    updated += result.count;
+  }
+  return updated;
+}
+
 function sanitizeUserRefs<T extends Record<string, unknown>>(
   rows: T[],
   fields: string[],
@@ -108,20 +157,26 @@ export async function POST(
   const payload = checkpoint.payload as unknown as CheckpointPayload;
   const actorId = await resolveActorId();
 
-  // 1. Save current state as pre_restore snapshot (expires in 7 days)
+  // 1. Save current state as pre_restore snapshot (expires per PRE_RESTORE_RETENTION_DAYS)
   const currentPayload = await buildCheckpointPayload();
-  const currentSerialized = JSON.stringify(currentPayload);
   const preRestore = await prisma.weeklyCheckpoint.create({
     data: {
       kind: "pre_restore",
       label: `Before restore of ${checkpoint.label ?? checkpoint.id}`,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       payload: currentPayload as any,
-      byteSize: Buffer.byteLength(currentSerialized, "utf8"),
+      byteSize: Buffer.byteLength(JSON.stringify(currentPayload), "utf8"),
       expiresAt: preRestoreExpiry(),
       createdById: actorId,
     },
   });
+
+  // 1-B. Link AuditLogs of disappearing rows to the pre_restore snapshot
+  const orphanCount = await linkOrphanAuditLogs(
+    preRestore.id,
+    currentPayload,
+    payload,
+  );
 
   // 2. Collect valid user ids for FK sanitization
   const users = await prisma.user.findMany({ select: { id: true } });
@@ -218,14 +273,15 @@ export async function POST(
     entityId: checkpoint.id,
     action: "restore",
     actorId,
-    summary: `Restored from checkpoint ${checkpoint.id}. Pre-restore: ${preRestore.id}`,
-    changes: { preRestoreCheckpointId: preRestore.id },
+    summary: `Restored from checkpoint ${checkpoint.id}. Pre-restore: ${preRestore.id}. Orphan logs linked: ${orphanCount}`,
+    changes: { preRestoreCheckpointId: preRestore.id, orphanCount },
   });
 
   return NextResponse.json({
     data: {
       checkpointId: checkpoint.id,
       preRestoreCheckpointId: preRestore.id,
+      orphanLogsLinked: orphanCount,
       restoredAt: new Date().toISOString(),
     },
   });

--- a/src/app/api/admin/checkpoints/[id]/restore/route.ts
+++ b/src/app/api/admin/checkpoints/[id]/restore/route.ts
@@ -1,26 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
+import { timingSafeEqual } from "node:crypto";
 import { prisma } from "@/lib/prisma";
 import { auth, requireAdmin } from "@/lib/auth";
 import { createAuditLog } from "@/lib/audit";
 import {
   buildCheckpointPayload,
   preRestoreExpiry,
+  CHECKPOINT_TRUNCATE_TABLES,
   type CheckpointPayload,
 } from "@/lib/checkpoint";
 
-const TRUNCATE_TABLES = [
-  "internal_note_versions",
-  "weekly_action_versions",
-  "progress_item_versions",
-  "business_versions",
-  "internal_notes",
-  "weekly_actions",
-  "weekly_cycles",
-  "progress_items",
-  "businesses",
-  "company_aliases",
-  "companies",
-];
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
 
 const USER_REF_FIELDS: Record<keyof CheckpointPayload, string[]> = {
   companies: ["createdById", "updatedById"],
@@ -89,7 +84,11 @@ export async function POST(
     );
   }
   const appPassword = process.env.APP_PASSWORD;
-  if (!appPassword || body.password !== appPassword) {
+  if (
+    !appPassword ||
+    typeof body.password !== "string" ||
+    !safeEqual(body.password, appPassword)
+  ) {
     return NextResponse.json(
       { error: "VALIDATION", message: "Invalid password" },
       { status: 400 },
@@ -132,7 +131,7 @@ export async function POST(
   try {
     await prisma.$transaction(
       async (tx) => {
-        const truncateSql = `TRUNCATE TABLE ${TRUNCATE_TABLES.map((t) => `"${t}"`).join(", ")} RESTART IDENTITY CASCADE`;
+        const truncateSql = `TRUNCATE TABLE ${CHECKPOINT_TRUNCATE_TABLES.map((t) => `"${t}"`).join(", ")} RESTART IDENTITY CASCADE`;
         await tx.$executeRawUnsafe(truncateSql);
 
         const companies = sanitizeUserRefs(

--- a/src/app/api/admin/checkpoints/[id]/restore/route.ts
+++ b/src/app/api/admin/checkpoints/[id]/restore/route.ts
@@ -1,0 +1,233 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { auth, requireAdmin } from "@/lib/auth";
+import { createAuditLog } from "@/lib/audit";
+import {
+  buildCheckpointPayload,
+  preRestoreExpiry,
+  type CheckpointPayload,
+} from "@/lib/checkpoint";
+
+const TRUNCATE_TABLES = [
+  "internal_note_versions",
+  "weekly_action_versions",
+  "progress_item_versions",
+  "business_versions",
+  "internal_notes",
+  "weekly_actions",
+  "weekly_cycles",
+  "progress_items",
+  "businesses",
+  "company_aliases",
+  "companies",
+];
+
+const USER_REF_FIELDS: Record<keyof CheckpointPayload, string[]> = {
+  companies: ["createdById", "updatedById"],
+  companyAliases: [],
+  businesses: ["createdById", "updatedById", "assignedToId"],
+  progressItems: ["createdById", "updatedById"],
+  weeklyCycles: [],
+  weeklyActions: ["createdById", "updatedById", "assignedToId"],
+  internalNotes: ["createdById", "updatedById"],
+};
+
+function sanitizeUserRefs<T extends Record<string, unknown>>(
+  rows: T[],
+  fields: string[],
+  validUserIds: Set<string>,
+): T[] {
+  if (fields.length === 0) return rows;
+  return rows.map((row) => {
+    const out: Record<string, unknown> = { ...row };
+    for (const f of fields) {
+      const v = out[f];
+      if (typeof v === "string" && !validUserIds.has(v)) {
+        out[f] = null;
+      }
+    }
+    return out as T;
+  });
+}
+
+async function resolveActorId(): Promise<string | null> {
+  const session = await auth();
+  const id = session?.user?.id;
+  if (!id) return null;
+  const exists = await prisma.user.findUnique({
+    where: { id },
+    select: { id: true },
+  });
+  return exists?.id ?? null;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    await requireAdmin();
+  } catch {
+    return NextResponse.json(
+      { error: "FORBIDDEN", message: "Admin role required" },
+      { status: 403 },
+    );
+  }
+
+  const { id } = await params;
+  let body: Record<string, unknown> = {};
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    // empty body
+  }
+
+  if (body.confirmText !== "RESTORE") {
+    return NextResponse.json(
+      { error: "VALIDATION", message: "confirmText must equal 'RESTORE'" },
+      { status: 400 },
+    );
+  }
+  const appPassword = process.env.APP_PASSWORD;
+  if (!appPassword || body.password !== appPassword) {
+    return NextResponse.json(
+      { error: "VALIDATION", message: "Invalid password" },
+      { status: 400 },
+    );
+  }
+
+  const checkpoint = await prisma.weeklyCheckpoint.findUnique({
+    where: { id },
+  });
+  if (!checkpoint) {
+    return NextResponse.json(
+      { error: "NOT_FOUND", message: "Checkpoint not found" },
+      { status: 404 },
+    );
+  }
+
+  const payload = checkpoint.payload as unknown as CheckpointPayload;
+  const actorId = await resolveActorId();
+
+  // 1. Save current state as pre_restore snapshot (expires in 7 days)
+  const currentPayload = await buildCheckpointPayload();
+  const currentSerialized = JSON.stringify(currentPayload);
+  const preRestore = await prisma.weeklyCheckpoint.create({
+    data: {
+      kind: "pre_restore",
+      label: `Before restore of ${checkpoint.label ?? checkpoint.id}`,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      payload: currentPayload as any,
+      byteSize: Buffer.byteLength(currentSerialized, "utf8"),
+      expiresAt: preRestoreExpiry(),
+      createdById: actorId,
+    },
+  });
+
+  // 2. Collect valid user ids for FK sanitization
+  const users = await prisma.user.findMany({ select: { id: true } });
+  const validUserIds = new Set(users.map((u) => u.id));
+
+  // 3. Single transaction: TRUNCATE CASCADE + re-insert in FK order
+  try {
+    await prisma.$transaction(
+      async (tx) => {
+        const truncateSql = `TRUNCATE TABLE ${TRUNCATE_TABLES.map((t) => `"${t}"`).join(", ")} RESTART IDENTITY CASCADE`;
+        await tx.$executeRawUnsafe(truncateSql);
+
+        const companies = sanitizeUserRefs(
+          payload.companies as Array<Record<string, unknown>>,
+          USER_REF_FIELDS.companies,
+          validUserIds,
+        );
+        if (companies.length) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await tx.company.createMany({ data: companies as any });
+        }
+
+        const companyAliases = payload.companyAliases as Array<
+          Record<string, unknown>
+        >;
+        if (companyAliases.length) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await tx.companyAlias.createMany({ data: companyAliases as any });
+        }
+
+        const businesses = sanitizeUserRefs(
+          payload.businesses as Array<Record<string, unknown>>,
+          USER_REF_FIELDS.businesses,
+          validUserIds,
+        );
+        if (businesses.length) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await tx.business.createMany({ data: businesses as any });
+        }
+
+        const progressItems = sanitizeUserRefs(
+          payload.progressItems as Array<Record<string, unknown>>,
+          USER_REF_FIELDS.progressItems,
+          validUserIds,
+        );
+        if (progressItems.length) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await tx.progressItem.createMany({ data: progressItems as any });
+        }
+
+        const weeklyCycles = payload.weeklyCycles as Array<
+          Record<string, unknown>
+        >;
+        if (weeklyCycles.length) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await tx.weeklyCycle.createMany({ data: weeklyCycles as any });
+        }
+
+        const weeklyActions = sanitizeUserRefs(
+          payload.weeklyActions as Array<Record<string, unknown>>,
+          USER_REF_FIELDS.weeklyActions,
+          validUserIds,
+        );
+        if (weeklyActions.length) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await tx.weeklyAction.createMany({ data: weeklyActions as any });
+        }
+
+        const internalNotes = sanitizeUserRefs(
+          payload.internalNotes as Array<Record<string, unknown>>,
+          USER_REF_FIELDS.internalNotes,
+          validUserIds,
+        );
+        if (internalNotes.length) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await tx.internalNote.createMany({ data: internalNotes as any });
+        }
+      },
+      { timeout: 60_000 },
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: "RESTORE_FAILED",
+        message: error instanceof Error ? error.message : "Unknown error",
+        preRestoreCheckpointId: preRestore.id,
+      },
+      { status: 500 },
+    );
+  }
+
+  await createAuditLog({
+    entityType: "weekly_checkpoint",
+    entityId: checkpoint.id,
+    action: "restore",
+    actorId,
+    summary: `Restored from checkpoint ${checkpoint.id}. Pre-restore: ${preRestore.id}`,
+    changes: { preRestoreCheckpointId: preRestore.id },
+  });
+
+  return NextResponse.json({
+    data: {
+      checkpointId: checkpoint.id,
+      preRestoreCheckpointId: preRestore.id,
+      restoredAt: new Date().toISOString(),
+    },
+  });
+}

--- a/src/app/api/admin/checkpoints/[id]/route.ts
+++ b/src/app/api/admin/checkpoints/[id]/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { auth, requireAdmin } from "@/lib/auth";
+import { createAuditLog } from "@/lib/audit";
+
+async function resolveActorId(): Promise<string | null> {
+  const session = await auth();
+  const id = session?.user?.id;
+  if (!id) return null;
+  const exists = await prisma.user.findUnique({
+    where: { id },
+    select: { id: true },
+  });
+  return exists?.id ?? null;
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    await requireAdmin();
+  } catch {
+    return NextResponse.json(
+      { error: "FORBIDDEN", message: "Admin role required" },
+      { status: 403 },
+    );
+  }
+
+  const { id } = await params;
+  const existing = await prisma.weeklyCheckpoint.findUnique({
+    where: { id },
+    select: { id: true, kind: true, label: true },
+  });
+  if (!existing) {
+    return NextResponse.json(
+      { error: "NOT_FOUND", message: "Checkpoint not found" },
+      { status: 404 },
+    );
+  }
+
+  await prisma.weeklyCheckpoint.delete({ where: { id } });
+
+  const actorId = await resolveActorId();
+  await createAuditLog({
+    entityType: "weekly_checkpoint",
+    entityId: id,
+    action: "delete",
+    actorId,
+    summary: `Checkpoint deleted (kind=${existing.kind}, label=${existing.label ?? "-"})`,
+  });
+
+  return NextResponse.json({ data: { id } });
+}

--- a/src/app/api/admin/checkpoints/cleanup/route.ts
+++ b/src/app/api/admin/checkpoints/cleanup/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import { cleanupExpiredCheckpoints } from "@/lib/checkpoint";
+
+export async function POST() {
+  try {
+    await requireAdmin();
+  } catch {
+    return NextResponse.json(
+      { error: "FORBIDDEN", message: "Admin role required" },
+      { status: 403 },
+    );
+  }
+
+  const deleted = await cleanupExpiredCheckpoints();
+  return NextResponse.json({ data: { deleted } });
+}

--- a/src/app/api/admin/checkpoints/cleanup/route.ts
+++ b/src/app/api/admin/checkpoints/cleanup/route.ts
@@ -12,6 +12,6 @@ export async function POST() {
     );
   }
 
-  const deleted = await cleanupExpiredCheckpoints();
-  return NextResponse.json({ data: { deleted } });
+  const result = await cleanupExpiredCheckpoints();
+  return NextResponse.json({ data: result });
 }

--- a/src/app/api/admin/checkpoints/route.ts
+++ b/src/app/api/admin/checkpoints/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth, requireAdmin } from "@/lib/auth";
 import { createAuditLog } from "@/lib/audit";
-import { createCheckpoint, cleanupExpiredCheckpoints } from "@/lib/checkpoint";
+import { createCheckpoint } from "@/lib/checkpoint";
 
 async function resolveActorId(): Promise<string | null> {
   const session = await auth();
@@ -24,9 +24,6 @@ export async function GET(request: NextRequest) {
       { status: 403 },
     );
   }
-
-  // Lazy cleanup of expired pre_restore checkpoints
-  await cleanupExpiredCheckpoints();
 
   const url = new URL(request.url);
   const kind = url.searchParams.get("kind");

--- a/src/app/api/admin/checkpoints/route.ts
+++ b/src/app/api/admin/checkpoints/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { auth, requireAdmin } from "@/lib/auth";
+import { createAuditLog } from "@/lib/audit";
+import { createCheckpoint, cleanupExpiredCheckpoints } from "@/lib/checkpoint";
+
+async function resolveActorId(): Promise<string | null> {
+  const session = await auth();
+  const id = session?.user?.id;
+  if (!id) return null;
+  const exists = await prisma.user.findUnique({
+    where: { id },
+    select: { id: true },
+  });
+  return exists?.id ?? null;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdmin();
+  } catch {
+    return NextResponse.json(
+      { error: "FORBIDDEN", message: "Admin role required" },
+      { status: 403 },
+    );
+  }
+
+  // Lazy cleanup of expired pre_restore checkpoints
+  await cleanupExpiredCheckpoints();
+
+  const url = new URL(request.url);
+  const kind = url.searchParams.get("kind");
+
+  const where: { kind?: string } = {};
+  if (kind === "weekly" || kind === "pre_restore") {
+    where.kind = kind;
+  }
+
+  const checkpoints = await prisma.weeklyCheckpoint.findMany({
+    where,
+    orderBy: { takenAt: "desc" },
+    select: {
+      id: true,
+      kind: true,
+      label: true,
+      year: true,
+      weekNumber: true,
+      byteSize: true,
+      takenAt: true,
+      expiresAt: true,
+      createdById: true,
+    },
+  });
+
+  return NextResponse.json({ data: checkpoints, total: checkpoints.length });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    await requireAdmin();
+  } catch {
+    return NextResponse.json(
+      { error: "FORBIDDEN", message: "Admin role required" },
+      { status: 403 },
+    );
+  }
+
+  let body: Record<string, unknown> = {};
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    // empty body ok
+  }
+
+  const label = typeof body.label === "string" ? body.label : null;
+  const year = typeof body.year === "number" ? body.year : null;
+  const weekNumber = typeof body.weekNumber === "number" ? body.weekNumber : null;
+
+  const createdById = await resolveActorId();
+
+  const checkpoint = await createCheckpoint({
+    kind: "weekly",
+    label,
+    year,
+    weekNumber,
+    createdById,
+  });
+
+  await createAuditLog({
+    entityType: "weekly_checkpoint",
+    entityId: checkpoint.id,
+    action: "create",
+    actorId: createdById,
+    summary: `Weekly checkpoint created (byteSize=${checkpoint.byteSize})`,
+  });
+
+  return NextResponse.json(
+    {
+      data: {
+        id: checkpoint.id,
+        kind: checkpoint.kind,
+        label: checkpoint.label,
+        year: checkpoint.year,
+        weekNumber: checkpoint.weekNumber,
+        byteSize: checkpoint.byteSize,
+        takenAt: checkpoint.takenAt,
+        expiresAt: checkpoint.expiresAt,
+      },
+    },
+    { status: 201 },
+  );
+}

--- a/src/app/api/admin/checkpoints/timeline/route.ts
+++ b/src/app/api/admin/checkpoints/timeline/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/auth";
+import { cleanupExpiredCheckpoints } from "@/lib/checkpoint";
+
+type TimelineEntry =
+  | {
+      type: "checkpoint";
+      at: string;
+      id: string;
+      kind: "weekly" | "pre_restore";
+      label: string | null;
+      year: number | null;
+      weekNumber: number | null;
+      byteSize: number | null;
+      expiresAt: string | null;
+      createdById: string | null;
+      auditCountSincePrev: number;
+    }
+  | {
+      type: "restore";
+      at: string;
+      id: string;
+      restoredCheckpointId: string;
+      restoredCheckpointLabel: string | null;
+      actorId: string | null;
+    };
+
+export async function GET() {
+  try {
+    await requireAdmin();
+  } catch {
+    return NextResponse.json(
+      { error: "FORBIDDEN", message: "Admin role required" },
+      { status: 403 },
+    );
+  }
+
+  await cleanupExpiredCheckpoints();
+
+  const checkpoints = await prisma.weeklyCheckpoint.findMany({
+    orderBy: { takenAt: "asc" },
+    select: {
+      id: true,
+      kind: true,
+      label: true,
+      year: true,
+      weekNumber: true,
+      byteSize: true,
+      takenAt: true,
+      expiresAt: true,
+      createdById: true,
+    },
+  });
+
+  const restoreLogs = await prisma.auditLog.findMany({
+    where: { entityType: "weekly_checkpoint", action: "restore" },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      entityId: true,
+      actorId: true,
+      createdAt: true,
+    },
+  });
+
+  // Audit count per interval (this checkpoint .. next checkpoint)
+  const counts = new Map<string, number>();
+  for (let i = 0; i < checkpoints.length; i++) {
+    const start = checkpoints[i].takenAt;
+    const end = checkpoints[i + 1]?.takenAt;
+    const count = await prisma.auditLog.count({
+      where: {
+        entityType: { notIn: ["weekly_checkpoint"] },
+        createdAt: {
+          gt: start,
+          ...(end ? { lte: end } : {}),
+        },
+      },
+    });
+    counts.set(checkpoints[i].id, count);
+  }
+
+  // Resolve restored checkpoint labels
+  const labelById = new Map<string, string | null>(
+    checkpoints.map((c) => [c.id, c.label]),
+  );
+
+  const entries: TimelineEntry[] = [
+    ...checkpoints.map(
+      (c): TimelineEntry => ({
+        type: "checkpoint",
+        at: c.takenAt.toISOString(),
+        id: c.id,
+        kind: c.kind as "weekly" | "pre_restore",
+        label: c.label,
+        year: c.year,
+        weekNumber: c.weekNumber,
+        byteSize: c.byteSize,
+        expiresAt: c.expiresAt ? c.expiresAt.toISOString() : null,
+        createdById: c.createdById,
+        auditCountSincePrev: counts.get(c.id) ?? 0,
+      }),
+    ),
+    ...restoreLogs.map(
+      (a): TimelineEntry => ({
+        type: "restore",
+        at: a.createdAt.toISOString(),
+        id: a.id,
+        restoredCheckpointId: a.entityId,
+        restoredCheckpointLabel: labelById.get(a.entityId) ?? null,
+        actorId: a.actorId,
+      }),
+    ),
+  ].sort((a, b) => (b.at < a.at ? -1 : b.at > a.at ? 1 : 0));
+
+  return NextResponse.json({ data: entries });
+}

--- a/src/app/api/admin/checkpoints/timeline/route.ts
+++ b/src/app/api/admin/checkpoints/timeline/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAdmin } from "@/lib/auth";
-import { cleanupExpiredCheckpoints } from "@/lib/checkpoint";
 
 type TimelineEntry =
   | {
@@ -36,52 +35,63 @@ export async function GET() {
     );
   }
 
-  await cleanupExpiredCheckpoints();
-
-  const checkpoints = await prisma.weeklyCheckpoint.findMany({
-    orderBy: { takenAt: "asc" },
-    select: {
-      id: true,
-      kind: true,
-      label: true,
-      year: true,
-      weekNumber: true,
-      byteSize: true,
-      takenAt: true,
-      expiresAt: true,
-      createdById: true,
-    },
-  });
-
-  const restoreLogs = await prisma.auditLog.findMany({
-    where: { entityType: "weekly_checkpoint", action: "restore" },
-    orderBy: { createdAt: "asc" },
-    select: {
-      id: true,
-      entityId: true,
-      actorId: true,
-      createdAt: true,
-    },
-  });
-
-  // Audit count per interval (this checkpoint .. next checkpoint)
-  const counts = new Map<string, number>();
-  for (let i = 0; i < checkpoints.length; i++) {
-    const start = checkpoints[i].takenAt;
-    const end = checkpoints[i + 1]?.takenAt;
-    const count = await prisma.auditLog.count({
-      where: {
-        entityType: { notIn: ["weekly_checkpoint"] },
-        createdAt: {
-          gt: start,
-          ...(end ? { lte: end } : {}),
-        },
+  const [checkpoints, restoreLogs, auditTimes] = await prisma.$transaction([
+    prisma.weeklyCheckpoint.findMany({
+      orderBy: { takenAt: "asc" },
+      select: {
+        id: true,
+        kind: true,
+        label: true,
+        year: true,
+        weekNumber: true,
+        byteSize: true,
+        takenAt: true,
+        expiresAt: true,
+        createdById: true,
       },
-    });
+    }),
+    prisma.auditLog.findMany({
+      where: { entityType: "weekly_checkpoint", action: "restore" },
+      orderBy: { createdAt: "asc" },
+      select: {
+        id: true,
+        entityId: true,
+        actorId: true,
+        createdAt: true,
+      },
+    }),
+    prisma.auditLog.findMany({
+      where: { entityType: { not: "weekly_checkpoint" } },
+      orderBy: { createdAt: "asc" },
+      select: { createdAt: true },
+    }),
+  ]);
+
+  // Count audit events per interval [checkpoint_i, checkpoint_{i+1})
+  // using a single pass through the pre-sorted audit log timestamps.
+  const counts = new Map<string, number>();
+  let logIdx = 0;
+  for (let i = 0; i < checkpoints.length; i++) {
+    const start = checkpoints[i].takenAt.getTime();
+    const end = checkpoints[i + 1]?.takenAt.getTime();
+    while (
+      logIdx < auditTimes.length &&
+      auditTimes[logIdx].createdAt.getTime() <= start
+    ) {
+      logIdx++;
+    }
+    let count = 0;
+    while (
+      logIdx < auditTimes.length &&
+      (end === undefined ||
+        auditTimes[logIdx].createdAt.getTime() <= end)
+    ) {
+      count++;
+      logIdx++;
+    }
     counts.set(checkpoints[i].id, count);
   }
 
-  // Resolve restored checkpoint labels
   const labelById = new Map<string, string | null>(
     checkpoints.map((c) => [c.id, c.label]),
   );
@@ -112,7 +122,12 @@ export async function GET() {
         actorId: a.actorId,
       }),
     ),
-  ].sort((a, b) => (b.at < a.at ? -1 : b.at > a.at ? 1 : 0));
+  ].sort((a, b) => {
+    // desc by timestamp; on tie, restore goes on top (more recent conceptually)
+    if (a.at !== b.at) return b.at < a.at ? -1 : 1;
+    if (a.type === b.type) return 0;
+    return a.type === "restore" ? -1 : 1;
+  });
 
   return NextResponse.json({ data: entries });
 }

--- a/src/app/api/admin/unlock/route.ts
+++ b/src/app/api/admin/unlock/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+import { requireAdmin } from "@/lib/auth";
+import {
+  ADMIN_UNLOCK_COOKIE,
+  adminUnlockToken,
+} from "@/lib/admin-unlock";
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    await requireAdmin();
+  } catch {
+    return NextResponse.json(
+      { error: "FORBIDDEN", message: "Admin role required" },
+      { status: 403 },
+    );
+  }
+
+  let body: Record<string, unknown> = {};
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    // empty body
+  }
+
+  const pw = process.env.ADMIN_UNLOCK_PASSWORD;
+  if (
+    !pw ||
+    typeof body.password !== "string" ||
+    !safeEqual(body.password, pw)
+  ) {
+    return NextResponse.json(
+      { error: "VALIDATION", message: "Invalid password" },
+      { status: 400 },
+    );
+  }
+
+  const token = await adminUnlockToken();
+  const res = NextResponse.json({ data: { unlocked: true } });
+  res.cookies.set(ADMIN_UNLOCK_COOKIE, token, {
+    httpOnly: true,
+    secure: request.nextUrl.protocol === "https:",
+    sameSite: "lax",
+    path: "/",
+  });
+  return res;
+}
+
+export async function DELETE() {
+  const res = NextResponse.json({ data: { unlocked: false } });
+  res.cookies.delete(ADMIN_UNLOCK_COOKIE);
+  return res;
+}

--- a/src/app/api/cron/checkpoint/route.ts
+++ b/src/app/api/cron/checkpoint/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest) {
     entityType: "weekly_checkpoint",
     entityId: checkpoint.id,
     action: "create",
-    summary: `Auto weekly checkpoint (${label}, byteSize=${checkpoint.byteSize}, cleaned=${cleaned})`,
+    summary: `Auto weekly checkpoint (${label}, byteSize=${checkpoint.byteSize}, cleanedCheckpoints=${cleaned.deletedCheckpoints}, cleanedOrphanLogs=${cleaned.deletedOrphanLogs})`,
   });
 
   return NextResponse.json({
@@ -49,7 +49,7 @@ export async function GET(request: NextRequest) {
       checkpointId: checkpoint.id,
       label: checkpoint.label,
       byteSize: checkpoint.byteSize,
-      cleanedUpPreRestore: cleaned,
+      cleanedUp: cleaned,
     },
   });
 }

--- a/src/app/api/cron/checkpoint/route.ts
+++ b/src/app/api/cron/checkpoint/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+import {
+  createCheckpoint,
+  cleanupExpiredCheckpoints,
+} from "@/lib/checkpoint";
+import { getCurrentWeek, formatWeekLabel } from "@/lib/weekly-cycle";
+import { createAuditLog } from "@/lib/audit";
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export async function GET(request: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  const auth = request.headers.get("authorization") ?? "";
+  const expected = secret ? `Bearer ${secret}` : null;
+  if (!expected || !safeEqual(auth, expected)) {
+    return NextResponse.json(
+      { error: "UNAUTHORIZED" },
+      { status: 401 },
+    );
+  }
+
+  const { year, weekNumber } = getCurrentWeek();
+  const label = `${formatWeekLabel(year, weekNumber)} auto`;
+
+  const checkpoint = await createCheckpoint({
+    kind: "weekly",
+    label,
+    year,
+    weekNumber,
+  });
+
+  const cleaned = await cleanupExpiredCheckpoints();
+
+  await createAuditLog({
+    entityType: "weekly_checkpoint",
+    entityId: checkpoint.id,
+    action: "create",
+    summary: `Auto weekly checkpoint (${label}, byteSize=${checkpoint.byteSize}, cleaned=${cleaned})`,
+  });
+
+  return NextResponse.json({
+    data: {
+      checkpointId: checkpoint.id,
+      label: checkpoint.label,
+      byteSize: checkpoint.byteSize,
+      cleanedUpPreRestore: cleaned,
+    },
+  });
+}

--- a/src/lib/admin-unlock.ts
+++ b/src/lib/admin-unlock.ts
@@ -1,0 +1,42 @@
+export const ADMIN_UNLOCK_COOKIE = "admin_unlock";
+
+function getSecret(): string {
+  const s = process.env.NEXTAUTH_SECRET ?? process.env.AUTH_SECRET;
+  if (!s) {
+    throw new Error(
+      "NEXTAUTH_SECRET or AUTH_SECRET is required for admin unlock",
+    );
+  }
+  return s;
+}
+
+export async function adminUnlockToken(): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(getSecret()),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode("admin-unlocked:v1"),
+  );
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function verifyAdminUnlockCookie(
+  value: string | undefined,
+): Promise<boolean> {
+  if (!value) return false;
+  const expected = await adminUnlockToken();
+  if (value.length !== expected.length) return false;
+  let eq = 0;
+  for (let i = 0; i < value.length; i++) {
+    eq |= value.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  return eq === 0;
+}

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,10 +1,22 @@
+import { NextRequest } from "next/server";
 import { prisma } from "./prisma";
+
+// x-forwarded-for is trusted only behind a reverse proxy (e.g. Vercel).
+// Truncate to 45 chars (max IPv6 length) to prevent oversized header injection.
+export function getClientIp(request: NextRequest): string | null {
+  const ip =
+    request.headers.get("x-forwarded-for")?.split(",")[0].trim() ||
+    request.headers.get("x-real-ip") ||
+    null;
+  return ip ? ip.slice(0, 45) : null;
+}
 
 interface CreateAuditLogParams {
   entityType: string;
   entityId: string;
   action: string;
   actorId?: string | null;
+  ip?: string | null;
   changes?: Record<string, unknown> | null;
   summary?: string | null;
 }
@@ -14,6 +26,7 @@ export async function createAuditLog({
   entityId,
   action,
   actorId = null,
+  ip = null,
   changes = null,
   summary = null,
 }: CreateAuditLogParams) {
@@ -23,6 +36,7 @@ export async function createAuditLog({
       entityId,
       action,
       actorId,
+      ip,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       changes: (changes ?? undefined) as any,
       summary,

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,22 +1,10 @@
-import { NextRequest } from "next/server";
 import { prisma } from "./prisma";
-
-// x-forwarded-for is trusted only behind a reverse proxy (e.g. Vercel).
-// Truncate to 45 chars (max IPv6 length) to prevent oversized header injection.
-export function getClientIp(request: NextRequest): string | null {
-  const ip =
-    request.headers.get("x-forwarded-for")?.split(",")[0].trim() ||
-    request.headers.get("x-real-ip") ||
-    null;
-  return ip ? ip.slice(0, 45) : null;
-}
 
 interface CreateAuditLogParams {
   entityType: string;
   entityId: string;
   action: string;
   actorId?: string | null;
-  ip?: string | null;
   changes?: Record<string, unknown> | null;
   summary?: string | null;
 }
@@ -26,7 +14,6 @@ export async function createAuditLog({
   entityId,
   action,
   actorId = null,
-  ip = null,
   changes = null,
   summary = null,
 }: CreateAuditLogParams) {
@@ -36,7 +23,6 @@ export async function createAuditLog({
       entityId,
       action,
       actorId,
-      ip,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       changes: (changes ?? undefined) as any,
       summary,

--- a/src/lib/checkpoint.ts
+++ b/src/lib/checkpoint.ts
@@ -22,6 +22,28 @@ export const CHECKPOINT_TABLES = [
   "internalNotes",
 ] as const satisfies readonly (keyof CheckpointPayload)[];
 
+/**
+ * Tables cleared during restore. Order doesn't matter for TRUNCATE CASCADE,
+ * but listed children-first for readability. Includes:
+ * - main data tables
+ * - per-row version tables (CASCADE'd anyway, but explicit)
+ * - recent_views (polymorphic, FK-less — must be explicit to avoid orphans)
+ */
+export const CHECKPOINT_TRUNCATE_TABLES = [
+  "internal_note_versions",
+  "weekly_action_versions",
+  "progress_item_versions",
+  "business_versions",
+  "recent_views",
+  "internal_notes",
+  "weekly_actions",
+  "weekly_cycles",
+  "progress_items",
+  "businesses",
+  "company_aliases",
+  "companies",
+] as const;
+
 export async function buildCheckpointPayload(): Promise<CheckpointPayload> {
   const [
     companies,
@@ -31,7 +53,7 @@ export async function buildCheckpointPayload(): Promise<CheckpointPayload> {
     weeklyCycles,
     weeklyActions,
     internalNotes,
-  ] = await Promise.all([
+  ] = await prisma.$transaction([
     prisma.company.findMany(),
     prisma.companyAlias.findMany(),
     prisma.business.findMany(),
@@ -70,8 +92,7 @@ export async function createCheckpoint({
   expiresAt = null,
 }: CreateCheckpointParams) {
   const payload = await buildCheckpointPayload();
-  const serialized = JSON.stringify(payload);
-  const byteSize = Buffer.byteLength(serialized, "utf8");
+  const byteSize = Buffer.byteLength(JSON.stringify(payload), "utf8");
 
   return prisma.weeklyCheckpoint.create({
     data: {

--- a/src/lib/checkpoint.ts
+++ b/src/lib/checkpoint.ts
@@ -109,18 +109,48 @@ export async function createCheckpoint({
   });
 }
 
+export const PRE_RESTORE_RETENTION_DAYS = 35;
+
 export function preRestoreExpiry(from: Date = new Date()): Date {
   const d = new Date(from);
-  d.setDate(d.getDate() + 7);
+  d.setDate(d.getDate() + PRE_RESTORE_RETENTION_DAYS);
   return d;
 }
 
-export async function cleanupExpiredCheckpoints(): Promise<number> {
-  const result = await prisma.weeklyCheckpoint.deleteMany({
+/**
+ * Delete expired pre_restore checkpoints along with any AuditLogs
+ * linked to them via snapshotCheckpointId. Returns counts so the caller
+ * can surface how much was pruned.
+ */
+export async function cleanupExpiredCheckpoints(): Promise<{
+  deletedCheckpoints: number;
+  deletedOrphanLogs: number;
+}> {
+  const expired = await prisma.weeklyCheckpoint.findMany({
     where: {
       kind: "pre_restore",
       expiresAt: { lt: new Date() },
     },
+    select: { id: true },
   });
-  return result.count;
+
+  if (expired.length === 0) {
+    return { deletedCheckpoints: 0, deletedOrphanLogs: 0 };
+  }
+
+  const ids = expired.map((c) => c.id);
+
+  const [logResult, ckptResult] = await prisma.$transaction([
+    prisma.auditLog.deleteMany({
+      where: { snapshotCheckpointId: { in: ids } },
+    }),
+    prisma.weeklyCheckpoint.deleteMany({
+      where: { id: { in: ids } },
+    }),
+  ]);
+
+  return {
+    deletedCheckpoints: ckptResult.count,
+    deletedOrphanLogs: logResult.count,
+  };
 }

--- a/src/lib/checkpoint.ts
+++ b/src/lib/checkpoint.ts
@@ -1,0 +1,105 @@
+import { prisma } from "./prisma";
+
+export type CheckpointKind = "weekly" | "pre_restore";
+
+export interface CheckpointPayload {
+  companies: unknown[];
+  companyAliases: unknown[];
+  businesses: unknown[];
+  progressItems: unknown[];
+  weeklyCycles: unknown[];
+  weeklyActions: unknown[];
+  internalNotes: unknown[];
+}
+
+export const CHECKPOINT_TABLES = [
+  "companies",
+  "companyAliases",
+  "businesses",
+  "progressItems",
+  "weeklyCycles",
+  "weeklyActions",
+  "internalNotes",
+] as const satisfies readonly (keyof CheckpointPayload)[];
+
+export async function buildCheckpointPayload(): Promise<CheckpointPayload> {
+  const [
+    companies,
+    companyAliases,
+    businesses,
+    progressItems,
+    weeklyCycles,
+    weeklyActions,
+    internalNotes,
+  ] = await Promise.all([
+    prisma.company.findMany(),
+    prisma.companyAlias.findMany(),
+    prisma.business.findMany(),
+    prisma.progressItem.findMany(),
+    prisma.weeklyCycle.findMany(),
+    prisma.weeklyAction.findMany(),
+    prisma.internalNote.findMany(),
+  ]);
+
+  return {
+    companies,
+    companyAliases,
+    businesses,
+    progressItems,
+    weeklyCycles,
+    weeklyActions,
+    internalNotes,
+  };
+}
+
+interface CreateCheckpointParams {
+  kind: CheckpointKind;
+  label?: string | null;
+  year?: number | null;
+  weekNumber?: number | null;
+  createdById?: string | null;
+  expiresAt?: Date | null;
+}
+
+export async function createCheckpoint({
+  kind,
+  label = null,
+  year = null,
+  weekNumber = null,
+  createdById = null,
+  expiresAt = null,
+}: CreateCheckpointParams) {
+  const payload = await buildCheckpointPayload();
+  const serialized = JSON.stringify(payload);
+  const byteSize = Buffer.byteLength(serialized, "utf8");
+
+  return prisma.weeklyCheckpoint.create({
+    data: {
+      kind,
+      label,
+      year,
+      weekNumber,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      payload: payload as any,
+      byteSize,
+      createdById,
+      expiresAt,
+    },
+  });
+}
+
+export function preRestoreExpiry(from: Date = new Date()): Date {
+  const d = new Date(from);
+  d.setDate(d.getDate() + 7);
+  return d;
+}
+
+export async function cleanupExpiredCheckpoints(): Promise<number> {
+  const result = await prisma.weeklyCheckpoint.deleteMany({
+    where: {
+      kind: "pre_restore",
+      expiresAt: { lt: new Date() },
+    },
+  });
+  return result.count;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getToken } from "next-auth/jwt";
+import {
+  ADMIN_UNLOCK_COOKIE,
+  verifyAdminUnlockCookie,
+} from "@/lib/admin-unlock";
 
 export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
@@ -42,12 +46,38 @@ export async function middleware(req: NextRequest) {
   }
 
   // Admin routes protection
-  if (pathname.startsWith("/admin") || pathname.startsWith("/api/admin")) {
+  if (
+    pathname.startsWith("/admin") ||
+    pathname.startsWith("/api/admin")
+  ) {
     if (role !== "admin") {
       if (isApiRoute) {
         return NextResponse.json({ error: "Forbidden" }, { status: 403 });
       }
       return NextResponse.redirect(new URL("/", req.url));
+    }
+
+    // Extra password gate — skip unlock page itself and the unlock endpoint
+    const skipGate =
+      pathname === "/admin-unlock" ||
+      pathname.startsWith("/admin-unlock/") ||
+      pathname === "/api/admin/unlock";
+
+    if (!skipGate) {
+      const unlocked = await verifyAdminUnlockCookie(
+        req.cookies.get(ADMIN_UNLOCK_COOKIE)?.value,
+      );
+      if (!unlocked) {
+        if (isApiRoute) {
+          return NextResponse.json(
+            { error: "UnlockRequired" },
+            { status: 401 },
+          );
+        }
+        const url = new URL("/admin-unlock", req.url);
+        url.searchParams.set("next", pathname);
+        return NextResponse.redirect(url);
+      }
     }
   }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,9 @@
 {
-  "regions": ["icn1"]
+  "regions": ["icn1"],
+  "crons": [
+    {
+      "path": "/api/cron/checkpoint",
+      "schedule": "0 15 * * 0"
+    }
+  ]
 }


### PR DESCRIPTION
Closes #194

## 요약
- 사업/주간보고 데이터의 **주간 전체 스냅샷**을 `WeeklyCheckpoint` 테이블에 JSONB로 저장
- 체크포인트를 선택해 **완전 롤백 복원**(TRUNCATE CASCADE + 재삽입)
- 복원 직전 상태는 `kind='pre_restore'` 체크포인트로 자동 저장 → 7일 후 자동 정리 (되돌리기의 되돌리기)
- 관리자 UI에 **타임라인 + 복원 분기 마커** 추가

## 범위
- **백업/복원 대상**: Company, CompanyAlias, Business, ProgressItem, WeeklyCycle, WeeklyAction, InternalNote
- **제외**: User, Account, Session, AuditLog, 기존 `*Version` 테이블, RecentView

## 안전 장치
- 관리자 역할 필수
- Dry-run diff 미리보기 (테이블별 willDelete/willInsert/willUpdate)
- 2단계 확인: `confirmText === "RESTORE"` + `password === APP_PASSWORD`
- 복원 이벤트는 AuditLog에 `entityType='weekly_checkpoint', action='restore'`로 기록 → 타임라인에 분기 마커로 표출
- 존재하지 않는 userId 참조는 null로 치환
- 단일 트랜잭션 (60초 timeout), 실패 시 pre_restore로 복구 가능

## 타임라인 / 분기 표현
`GET /api/admin/checkpoints/timeline`이 체크포인트 + 복원 AuditLog를 시간순 병합하여 반환하며, 각 체크포인트에 해당 시점 이후 구간의 변경 건수(`auditCountSincePrev`)를 포함합니다. 복원 이벤트 아래쪽(더 과거) 항목들은 UI에서 흐리게 표시되어 "이전 가지"임을 표현합니다.

## 용량 추정
- 주당 3~10MB (JSONB 압축 후)
- 연간 150~500MB — 현재 Postgres 구성에서 여유

## 추가/수정된 파일
- `prisma/schema.prisma` — WeeklyCheckpoint 모델 + User 관계
- `prisma/migrations/20260421010000_add_weekly_checkpoint/migration.sql`
- `src/lib/checkpoint.ts` — buildPayload / createCheckpoint / cleanupExpired / preRestoreExpiry
- `src/app/api/admin/checkpoints/route.ts` — GET 목록, POST 생성
- `src/app/api/admin/checkpoints/[id]/diff/route.ts` — dry-run diff
- `src/app/api/admin/checkpoints/[id]/restore/route.ts` — 복원
- `src/app/api/admin/checkpoints/cleanup/route.ts` — 만료 정리
- `src/app/api/admin/checkpoints/timeline/route.ts` — 타임라인 병합
- `src/app/admin/checkpoints/page.tsx` — 관리자 UI (타임라인 + diff/복원 모달)
- `src/app/admin/layout.tsx` — 사이드 메뉴에 "체크포인트" 추가

## 로컬 검증 순서
- [ ] `npx prisma migrate dev --name add_weekly_checkpoint` 로 마이그레이션 적용
- [ ] `/admin/checkpoints` 접속 후 스냅샷 생성 (라벨 입력)
- [ ] 사업/주간액션 몇 건 수정·삭제 → diff 버튼에서 변화 카운트 확인
- [ ] 복원 실행 (`RESTORE` + APP_PASSWORD) → 데이터 원복, pre_restore 자동 생성 확인
- [ ] 타임라인에 **⟲ 복원됨** 마커 + 아래쪽 항목 흐리게 표시 확인
- [ ] pre_restore 체크포인트 만료일(+7일) 확인

## 주의
이 PR은 **기존 `*Version` 테이블은 FK CASCADE로 복원 시 함께 초기화됩니다**. row 단위 편집 이력 보존이 필요해지면 별도 이슈로 FK 재설계 작업을 진행해야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
