### PR TITLE
feat: DB keepalive cron (daily SELECT 1)

### DIFF
--- a/src/app/api/cron/db-ping/route.ts
+++ b/src/app/api/cron/db-ping/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+import { prisma } from "@/lib/prisma";
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+export async function GET(request: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  const auth = request.headers.get("authorization") ?? "";
+  const expected = secret ? `Bearer ${secret}` : null;
+  if (!expected || !safeEqual(auth, expected)) {
+    return NextResponse.json({ error: "UNAUTHORIZED" }, { status: 401 });
+  }
+
+  await prisma.$queryRaw`SELECT 1`;
+  return NextResponse.json({ ok: true, ts: new Date().toISOString() });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
     {
       "path": "/api/cron/checkpoint",
       "schedule": "0 15 * * 0"
+    },
+    {
+      "path": "/api/cron/db-ping",
+      "schedule": "0 0 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- 일주일+ 비활성 시 서버리스 Postgres가 슬립되는 문제 방지
- `/api/cron/db-ping` 신규 — 매일 KST 09:00 (UTC 00:00) 에 `SELECT 1` 실행
- 기존 `/api/cron/checkpoint`와 동일한 `CRON_SECRET` Bearer 인증 패턴 재사용
- Vercel Hobby cron 한도 내 (현재 2개)

## Review
Codex high-effort review 통과 (SHIP). 옵셔널 개선(SELECT 1 실패 시 503) 외 블로커 없음.

## Test plan
- [ ] Vercel 배포 후 Cron 탭에서 `/api/cron/db-ping` 스케줄 인식 확인
- [ ] 다음 트리거 시점에 200 응답 + `{ok: true, ts: ...}` 로그 확인
- [ ] CRON_SECRET 없이 호출 시 401 확인
- [ ] 1주일 후 첫 접속이 cold start 없이 즉시 응답하는지 체감 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)